### PR TITLE
Restructuring Firestore database

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -14,9 +14,9 @@ import (
 )
 
 type Datastore interface {
-	All() ([]types.JournalEntry, error)
+	All(username string) ([]types.JournalEntry, error)
 	Get(username string, date string) (types.JournalEntry, error)
-	Insert(types.JournalEntry) error
+	Insert(username string, j types.JournalEntry) error
 	Close() error
 }
 
@@ -57,8 +57,8 @@ func New() Datastore {
 	}
 }
 
-func (c defaultClient) All() (entries []types.JournalEntry, err error) {
-	iter := c.firestoreClient.Collection("journalEntries").Documents(c.ctx)
+func (c defaultClient) All(username string) (entries []types.JournalEntry, err error) {
+	iter := c.firestoreClient.Collection("journalEntries").Doc(username).Collection("entries").Documents(c.ctx)
 	for {
 		doc, err := iter.Next()
 		if err == iterator.Done {
@@ -75,7 +75,7 @@ func (c defaultClient) All() (entries []types.JournalEntry, err error) {
 }
 
 func (c defaultClient) Get(username string, date string) (types.JournalEntry, error) {
-	iter := c.firestoreClient.Collection("journalEntries").Documents(c.ctx)
+	iter := c.firestoreClient.Collection("journalEntries").Doc(username).Collection("entries").Documents(c.ctx)
 	for {
 		doc, err := iter.Next()
 		if err == iterator.Done {
@@ -96,8 +96,8 @@ func (c defaultClient) Get(username string, date string) (types.JournalEntry, er
 	}
 }
 
-func (c defaultClient) Insert(j types.JournalEntry) error {
-	_, err := c.firestoreClient.Collection("journalEntries").Doc(j.Date).Set(c.ctx, j)
+func (c defaultClient) Insert(username string, j types.JournalEntry) error {
+	_, err := c.firestoreClient.Collection("journalEntries").Doc(username).Collection("entries").Doc(j.Date).Set(c.ctx, j)
 	return err
 }
 

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -9,8 +9,9 @@ func (s *defaultServer) routes() {
 	s.router.PathPrefix("/js").Handler(fs)
 	s.router.PathPrefix("/css").Handler(fs)
 
-	s.router.HandleFunc("/api/entries", s.entriesHandler())
+	s.router.HandleFunc("/api/entries/{username}", s.entriesHandler())
 	s.router.HandleFunc("/api/entry/{username}/{date}", s.entryHandler())
 	s.router.HandleFunc("/api/submit", s.submitHandler())
+	s.router.PathPrefix("/api").HandlerFunc(s.apiRootHandler())
 	s.router.PathPrefix("/").HandlerFunc(s.indexHandler())
 }

--- a/web/frontend/src/components/ViewEntry.vue
+++ b/web/frontend/src/components/ViewEntry.vue
@@ -80,7 +80,9 @@ export default {
     }
   },
   created() {
-    const url = `${process.env.VUE_APP_BACKEND_URL}/api/entries`;
+    const url = `${process.env.VUE_APP_BACKEND_URL}/api/entries/${
+      this.$route.params.username
+    }`;
     this.$http
       .get(url)
       .then(result => {


### PR DESCRIPTION
Before:
  /journalEntries/[date]
After:
  /journalEntries/[username]/entries/[date]

Also adds validation to ensure that clients can't pass invalid dates or empty usernames