### PR TITLE
Fetching recent entries at site load time

### DIFF
--- a/web/frontend/src/components/Initializer.vue
+++ b/web/frontend/src/components/Initializer.vue
@@ -5,6 +5,8 @@
 </template>
 
 <script>
+import refreshRecent from "../controllers/Recent.js";
+
 export default {
   name: "Initializer",
   methods: {
@@ -38,6 +40,7 @@ export default {
   },
   created() {
     this.checkLoginState(5);
+    refreshRecent();
   }
 };
 </script>

--- a/web/frontend/src/components/Recent.vue
+++ b/web/frontend/src/components/Recent.vue
@@ -2,7 +2,6 @@
   <div>
     <h1>Recent Entries</h1>
     <p>Check out what other users got done this week:</p>
-    <p v-if="backendError" class="error">Failed to connect to backend: {{ backendError }}</p>
 
     <PartialJournal v-bind:key="item.key" v-bind:entry="item" v-for="item in recentEntries"/>
   </div>
@@ -11,36 +10,20 @@
 <script>
 import PartialJournal from "./PartialJournal.vue";
 
+import refreshRecent from "../controllers/Recent.js";
+
 export default {
   name: "Recent",
   components: {
     PartialJournal
   },
-  data() {
-    return {
-      recentEntries: [],
-      backendError: null
-    };
+  computed: {
+    recentEntries() {
+      return this.$store.state.recentEntries;
+    }
   },
   created() {
-    const url = `${process.env.VUE_APP_BACKEND_URL}/api/recentEntries`;
-    this.$http
-      .get(url)
-      .then(result => {
-        this.recentEntries = [];
-        for (const entry of result.data) {
-          const formattedDate = new Date(entry.date).toISOString().slice(0, 10);
-          this.recentEntries.push({
-            key: `/${entry.author}/${formattedDate}`,
-            author: entry.author,
-            date: entry.date,
-            markdown: entry.markdown
-          });
-        }
-      })
-      .catch(error => {
-        this.backendError = error;
-      });
+    refreshRecent();
   }
 };
 </script>

--- a/web/frontend/src/controllers/Recent.js
+++ b/web/frontend/src/controllers/Recent.js
@@ -1,0 +1,21 @@
+import axios from "axios";
+import store from "../store.js";
+
+export default function refreshRecent() {
+  const url = `${process.env.VUE_APP_BACKEND_URL}/api/recentEntries`;
+  axios
+    .get(url)
+    .then(result => {
+      const recentEntries = [];
+      for (const entry of result.data) {
+        const formattedDate = new Date(entry.date).toISOString().slice(0, 10);
+        recentEntries.push({
+          key: `/${entry.author}/${formattedDate}`,
+          author: entry.author,
+          date: entry.date,
+          markdown: entry.markdown
+        });
+      }
+      store.commit("setRecent", recentEntries);
+    });
+}

--- a/web/frontend/src/store.js
+++ b/web/frontend/src/store.js
@@ -10,7 +10,8 @@ const vuexLocal = new VuexPersistence({
 
 export default new Vuex.Store({
   state: {
-    username: null
+    username: null,
+    recentEntries: null
   },
   mutations: {
     setUsername(state, username) {
@@ -18,7 +19,10 @@ export default new Vuex.Store({
     },
     clearUsername(state) {
       state.username = null;
-    }
+    },
+    setRecent(state, entries) {
+      state.recentEntries = entries;
+    },
   },
   plugins: [vuexLocal.plugin]
 });


### PR DESCRIPTION
This gets rid of the delay waiting for entries to load when the user visits the /recent route