### PR TITLE
Adding a temporary backfill function to populate drafts

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -96,6 +96,37 @@ func (s *defaultServer) entriesHandler() http.HandlerFunc {
 	}
 }
 
+func (s *defaultServer) backfillDraftsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		users, err := s.datastore.Users()
+		if err != nil {
+			log.Printf("Failed to retrieve users: %s", err)
+			http.Error(w, fmt.Sprintf("Failed to retrieve users: %s", err), http.StatusInternalServerError)
+			return
+		}
+
+		for _, username := range users {
+			log.Printf("Backfilling for user %s", username)
+			userEntries, err := s.datastore.All(username)
+			if err != nil {
+				log.Printf("Failed to retrieve entries for user %s: %s", username, err)
+				http.Error(w, fmt.Sprintf("Failed to retrieve entries for user %s: %s", username, err), http.StatusInternalServerError)
+				return
+			}
+			for _, entry := range userEntries {
+				_, err := s.datastore.GetDraft(username, entry.Date)
+				if _, ok := err.(datastore.DraftNotFoundError); ok {
+					log.Printf("Backfilling draft for: %s -> %s", username, entry.Date)
+					s.datastore.InsertDraft(username, entry)
+				} else if err != nil {
+					log.Printf("Failed to retrieve draft entry: %s", err)
+				}
+			}
+		}
+		log.Print("Finished backfill")
+	}
+}
+
 func (s *defaultServer) recentEntriesHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		users, err := s.datastore.Users()

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -16,6 +16,7 @@ func (s *defaultServer) routes() {
 	s.router.HandleFunc("/api/recentEntries", s.enableCors(s.recentEntriesHandler()))
 	s.router.HandleFunc("/api/user/me", s.enableCors(s.userMeHandler()))
 	s.router.HandleFunc("/api/submit", s.enableCors(s.submitHandler()))
+	s.router.HandleFunc("/api/backfillDrafts", s.enableCors(s.backfillDraftsHandler()))
 	s.router.HandleFunc("/api/logout", s.enableCors(s.logoutHandler()))
 	s.router.PathPrefix("/api").HandlerFunc(s.enableCors(s.apiRootHandler()))
 


### PR DESCRIPTION
Because the editing screen now pulls drafts instead of journal entries, we need to copy legacy entries into drafts