### PR TITLE
Revert "Adding a temporary backfill function to populate drafts (#183)"

### DIFF
--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -16,7 +16,6 @@ func (s *defaultServer) routes() {
 	s.router.HandleFunc("/api/recentEntries", s.enableCors(s.recentEntriesHandler()))
 	s.router.HandleFunc("/api/user/me", s.enableCors(s.userMeHandler()))
 	s.router.HandleFunc("/api/submit", s.enableCors(s.submitHandler()))
-	s.router.HandleFunc("/api/backfillDrafts", s.enableCors(s.backfillDraftsHandler()))
 	s.router.HandleFunc("/api/logout", s.enableCors(s.logoutHandler()))
 	s.router.PathPrefix("/api").HandlerFunc(s.enableCors(s.apiRootHandler()))
 


### PR DESCRIPTION
This reverts commit 24150b1cf67d71783ff66e72801ae386619bd8d7.

Backfill is complete, so we don't need this functionality.