### PR TITLE
Cutting /me redirect handler

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -71,17 +71,6 @@ func (s defaultServer) submitPageHandler() http.HandlerFunc {
 	}
 }
 
-func (s defaultServer) meRedirectHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		u, err := s.loggedInUser(r)
-		if err != nil {
-			http.Redirect(w, r, "/login", http.StatusFound)
-			return
-		}
-		http.Redirect(w, r, "/"+u, http.StatusFound)
-	}
-}
-
 func (s *defaultServer) entriesHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		entries, err := s.datastore.All(usernameFromRequestPath(r))

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -20,6 +20,5 @@ func (s *defaultServer) routes() {
 	s.router.PathPrefix("/api").HandlerFunc(s.enableCors(s.apiRootHandler()))
 
 	s.router.HandleFunc("/submit", s.enableCsp(s.submitPageHandler()))
-	s.router.HandleFunc("/me", s.enableCsp(s.meRedirectHandler()))
 	s.router.PathPrefix("/").HandlerFunc(s.enableCsp(s.indexHandler()))
 }


### PR DESCRIPTION
It's dead code now that the client caches the logged-in user's username.