### PR TITLE
Extending default command timeout for Cypress

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,4 +1,5 @@
 {
   "pluginsFile": false,
-  "supportFile": false
+  "supportFile": false,
+  "defaultCommandTimeout": 10000
 }


### PR DESCRIPTION
UserKit is slowing down a bit and sometimes times out before the UI widget loads