### PR TITLE
Fixing bug in reactions e2e test

### DIFF
--- a/e2e/cypress/integration/spec.js
+++ b/e2e/cypress/integration/spec.js
@@ -121,19 +121,20 @@ it('logs in and reacts to an entry', () => {
   cy.wait('@postUserKitLogin')
 
   // Clear any existing reaction on the entry.
-  cy.request('POST', '/api/reactions/entry/staging.jimmy/2019-06-28', { reactionSymbol: "" }).as('postClearReaction')
+  cy.request('POST', '/api/reactions/entry/staging.jimmy/2019-06-28', { reactionSymbol: "" }).then(() => {
 
-  cy.visit('/staging.jimmy/2019-06-28')
+    // Visit a post and react to the entry.
+    cy.visit('/staging.jimmy/2019-06-28')
 
-  cy.route('POST', '/api/reactions/entry/staging.jimmy/2019-06-28').as('postReaction')
-  cy.get('.reaction-buttons .btn:first-of-type').click();
-  cy.wait('@postReaction').then(() => {
+    cy.get('.reaction-buttons .btn:first-of-type').click();
+
     // TODO(mtlynch): We should really be selecting the *first* div.reaction element.
     cy.get('.reaction')
       .then((element) => {
         expect(element.text().replace(/\s+/g, ' ')).to.equal('staging.jimmy reacted with a 👍');
       });
   });
+
 })
 
 it('logs in and signs out', () => {

--- a/web/frontend/src/components/Reactions.vue
+++ b/web/frontend/src/components/Reactions.vue
@@ -50,15 +50,22 @@ export default {
         .get(url)
         .then(result => {
           for (const reaction of result.data) {
+            if (reaction.username == this.loggedInUsername) {
+              if (this.selectedReaction == "") {
+                this.selectedReaction = reaction.symbol;
+              } else {
+                // Don't overwrite the local reaction symbol if the user
+                // clicked a reaction before the request finished.
+                continue;
+              }
+            }
+
             reactions.push({
               key: reaction.username,
               username: reaction.username,
               timestamp: new Date(reaction.timestamp),
               reaction: reaction.symbol
             });
-            if (reaction.username == this.loggedInUsername) {
-              this.selectedReaction = reaction.symbol;
-            }
           }
           // Sort from newest to oldest.
           reactions.sort((a, b) => b.timestamp - a.timestamp);


### PR DESCRIPTION
It turned out there was a race condition between the test automation clicking the button and the page overwriting the reactions with the server's response.

Fixed the behavior so the server no longer overwrites the local user's action.