### PR TITLE
Watching entry edit page for date changes

### DIFF
--- a/frontend/src/views/Submit.vue
+++ b/frontend/src/views/Submit.vue
@@ -139,6 +139,13 @@ export default {
     entryContent: function() {
       this.changesSaved = false;
       this.saveLabel = "Save Draft";
+    },
+    $route(to, from) {
+      if (to.params.date != from.params.date) {
+        if (isValidEntryDate(to.params.date)) {
+          this.date = to.params.date;
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
Before, the page wouldn't update if you'd click 'Post Update' while editing a previous entry