### PR TITLE
Fixing CSRF (hopefully for good)

### DIFF
--- a/backend/handlers/csrf_middleware.go
+++ b/backend/handlers/csrf_middleware.go
@@ -14,7 +14,8 @@ func newCsrfMiddleware() httpMiddlewareHandler {
 	}
 	return csrf.Protect(
 		[]byte(csrfSeed),
-		csrf.CookieName("csrf_base"),
-		csrf.Path("/api/"),
+		// The v2 suffix is just to prevent clients from re-using a previous version of the cookie.
+		csrf.CookieName("csrf_base_v2"),
+		csrf.Path("/"),
 		csrf.Secure(false))
 }

--- a/backend/handlers/csrf_prod.go
+++ b/backend/handlers/csrf_prod.go
@@ -12,8 +12,6 @@ func (s defaultServer) enableCsrf(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-CSRF-Token", csrf.Token(r))
 
-		// Temporarily disable CSRF protection until I figure out what's broken.
-		h(w, r) // TODO(mtlynch): Remove this and uncomment next line.
-		//s.csrfMiddleware(h).ServeHTTP(w, r)
+		s.csrfMiddleware(h).ServeHTTP(w, r)
 	}
 }

--- a/frontend/src/views/Logout.vue
+++ b/frontend/src/views/Logout.vue
@@ -21,7 +21,7 @@ export default {
       .finally(() => {
         // Logout can fail if CSRF goes out of state. In this case, still
         // delete the CSRF cookie.
-        this.deleteCookie("csrf_base");
+        this.deleteCookie("csrf_base2");
       });
   },
   methods: {


### PR DESCRIPTION
It was breaking before because the cookie's Path was set to /api. This was sensible in that only /api routes need CSRF validation, but it also meant that the server would keep resetting the csrf_base token on any request not to /api. It would work in single tab, but broke if the user opened multiple browser tabs and tried to make POST requests that required CSRF validation.

This makes the cookie path to just / and renames csrf_base to csrf_base2 so we don't conflict with users who have the previous cookie already set.