### PR TITLE
Changing link rel from nofollow to ugc

### DIFF
--- a/frontend/src/components/Journal.vue
+++ b/frontend/src/components/Journal.vue
@@ -5,7 +5,7 @@
       <vue-markdown
         :linkify="false"
         :html="false"
-        :anchorAttributes="{rel: 'nofollow' }"
+        :anchorAttributes="{rel: 'ugc' }"
         :source="entry.markdown"
       ></vue-markdown>
       <div class="last-modified-date">Last modified {{ entry.lastModified | moment("lll") }}</div>

--- a/frontend/src/components/JournalPreview.vue
+++ b/frontend/src/components/JournalPreview.vue
@@ -5,7 +5,7 @@
       <vue-markdown
         :linkify="false"
         :html="false"
-        :anchorAttributes="{rel: 'nofollow' }"
+        :anchorAttributes="{rel: 'ugc' }"
         :source="markdown"
       ></vue-markdown>
     </div>

--- a/frontend/src/components/PartialJournal.vue
+++ b/frontend/src/components/PartialJournal.vue
@@ -6,7 +6,7 @@
         <vue-markdown
           :linkify="false"
           :html="false"
-          :anchorAttributes="{rel: 'nofollow' }"
+          :anchorAttributes="{rel: 'ugc' }"
           :source="entrySnippet"
         ></vue-markdown>
       </div>


### PR DESCRIPTION
ugc is more appropriate because it's user-generated content

Reference: https://support.google.com/webmasters/answer/96569?hl=en