### PR TITLE
Setting journal entries to scroll on overflow

### DIFF
--- a/frontend/src/components/Journal.vue
+++ b/frontend/src/components/Journal.vue
@@ -35,6 +35,7 @@ export default {
 <style scoped>
 .journal-body {
   text-align: left;
+  overflow: scroll;
 }
 
 .last-modified-date {

--- a/frontend/src/components/JournalPreview.vue
+++ b/frontend/src/components/JournalPreview.vue
@@ -35,6 +35,7 @@ export default {
   background-color: #4e5d6c;
   border: 1px solid rgb(90, 90, 90);
   text-align: left;
+  overflow: scroll;
 }
 
 .preview-bar {

--- a/frontend/src/components/PartialJournal.vue
+++ b/frontend/src/components/PartialJournal.vue
@@ -50,6 +50,7 @@ div.journal {
   padding: 10px;
   margin-bottom: 60px;
   background-color: #4e5d6c;
+  overflow: scroll;
 }
 
 @media screen and (min-width: 768px) {


### PR DESCRIPTION
Otherwise, on mobile, text can cause the entire page to scroll