### PR TITLE
Skip e2e tests on forked pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,18 @@
 version: 2.1
+commands:
+  early_return_for_forked_pull_requests:
+    description: >-
+      If this build is from a fork, stop executing the current job and return success.
+      This is useful to avoid steps that will fail due to missing environment
+      variables.
+    steps:
+      - run:
+          name: Early return if this build is from a forked PR
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
 jobs:
   build-frontend:
     docker:
@@ -34,6 +48,7 @@ jobs:
   e2e:
     machine: true
     steps:
+      - early_return_for_forked_pull_requests
       - checkout
       - run:
           name: Retrieve staging GCP credentials from CircleCI


### PR DESCRIPTION
Forked pull requests don't have access to secret environment variables, so e2e tests will always fail. Add a step to automatically skip the e2e step on forked PRs, so we can at least run the unit tests.