### PR TITLE
Fixing alignment in journal header

### DIFF
--- a/frontend/src/components/JournalHeader.vue
+++ b/frontend/src/components/JournalHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <p class="journal-header">
+  <p class="journal-header text-center">
     <Username :username="entryAuthor" />'s update for the week ending on
     <b>{{ entryDate | moment("utc", "dddd, ll") }}</b>
   </p>

--- a/frontend/src/components/PartialJournal.vue
+++ b/frontend/src/components/PartialJournal.vue
@@ -10,7 +10,9 @@
           :source="entrySnippet"
         ></vue-markdown>
       </div>
-      <b-button variant="primary" :to="entry.key">More</b-button>
+      <div class="text-center">
+        <b-button variant="primary" :to="entry.key">More</b-button>
+      </div>
     </div>
   </div>
 </template>
@@ -79,11 +81,5 @@ div.journal {
 .journal-body {
   text-align: left;
   margin-bottom: 50px;
-}
-
-.read-more {
-  padding: 8px 25px;
-  background: rgb(0, 167, 97);
-  border-color: rgb(0, 0, 0);
 }
 </style>


### PR DESCRIPTION
The journal elements should remain centered even if parent elements are left-aligned