### PR TITLE
Removing Close method from datastore

### DIFF
--- a/backend/datastore/datastore.go
+++ b/backend/datastore/datastore.go
@@ -35,9 +35,6 @@ type Datastore interface {
 	// AddReaction saves a reader reaction associated with a published entry,
 	// overwriting any existing reaction.
 	AddReaction(entryAuthor string, entryDate string, reaction types.Reaction) error
-	// Close cleans up datastore resources. Clients should not call any Datastore
-	// functions after calling Close().
-	Close() error
 }
 
 // DraftNotFoundError occurs when no draft exists for a user with a given date.

--- a/backend/datastore/firestore/close.go
+++ b/backend/datastore/firestore/close.go
@@ -1,7 +1,0 @@
-package firestore
-
-// Close cleans up datastore resources. Clients should not call any Datastore
-// functions after calling Close().
-func (c client) Close() error {
-	return c.firestoreClient.Close()
-}


### PR DESCRIPTION
It turns out that nothing was actually ever calling this method. We don't need it because we never have to close the connection to the datastore.