### PR TITLE
Adding frame-src to CSP

### DIFF
--- a/backend/handlers/csp_common.go
+++ b/backend/handlers/csp_common.go
@@ -23,6 +23,10 @@ func contentSecurityPolicy() string {
 		"https://fonts.googleapis.com",
 		"https://fonts.gstatic.com",
 	}, " ")
+	frameSrc := strings.Join([]string{
+		// URLs for /login route (UserKit)
+		"https://www.google.com/recaptcha/",
+	})
 	imgSrc := strings.Join([]string{
 		"'self'",
 		// For bootstrap navbar images
@@ -31,5 +35,5 @@ func contentSecurityPolicy() string {
 		"https://www.google-analytics.com",
 	},
 		" ")
-	return fmt.Sprintf("script-src-elem %s; style-src-elem %s; img-src %s", scriptSrcElem, styleSrcElem, imgSrc)
+	return fmt.Sprintf("script-src-elem %s; style-src-elem %s; frame-src: %s; img-src %s", scriptSrcElem, styleSrcElem, frameSrc, imgSrc)
 }

--- a/backend/handlers/csp_common.go
+++ b/backend/handlers/csp_common.go
@@ -26,7 +26,7 @@ func contentSecurityPolicy() string {
 	frameSrc := strings.Join([]string{
 		// URLs for /login route (UserKit)
 		"https://www.google.com/recaptcha/",
-	})
+	}, " ")
 	imgSrc := strings.Join([]string{
 		"'self'",
 		// For bootstrap navbar images


### PR DESCRIPTION
It turns out that Google expects this directive for reCaptcha and we were missing it.

https://developers.google.com/recaptcha/docs/faq#im-using-content-security-policy-csp-on-my-website.-how-can-i-configure-it-to-work-with-recaptcha