### PR TITLE
Adding a delay into the e2e test

### DIFF
--- a/e2e/cypress/integration/spec.js
+++ b/e2e/cypress/integration/spec.js
@@ -1,11 +1,17 @@
 Cypress.Commands.add('login', (username, password, options = {}) => {
   cy.visit('/login')
 
+  // Temporary workaround: Wait a few ms before logging in, otherwise UserKit
+  // fails with "Too many requests." This should go away in a few days when we
+  // switch to the upcoming dummy app ID with no limits.
+  cy.wait(250)
+
   cy.get('#userkit_username')
     .type(username)
   cy.get('#userkit_password')
     .type(password)
   cy.get('form').submit()
+
 })
 
 it('loads the homepage', () => {

--- a/e2e/cypress/integration/spec.js
+++ b/e2e/cypress/integration/spec.js
@@ -11,7 +11,6 @@ Cypress.Commands.add('login', (username, password, options = {}) => {
   cy.get('#userkit_password')
     .type(password)
   cy.get('form').submit()
-
 })
 
 it('loads the homepage', () => {


### PR DESCRIPTION
This is a temporary workaround to prevent the Too Many Requests errors we're seeing in UserKit. When we switch to the dev app ID, this should go away.