### PR TITLE
Specify in log in / log out e2e test that Account dropdown disappears

### DIFF
--- a/e2e/cypress/integration/spec.js
+++ b/e2e/cypress/integration/spec.js
@@ -185,6 +185,8 @@ it('logs in and signs out', () => {
 
   cy.visit('/logout')
   cy.location('pathname').should('eq', '/')
+
+  cy.get('nav .account-dropdown').should('not.exist');
 })
 
 it('views a non-existing user profile with empty information', () => {


### PR DESCRIPTION
After the user signs out, the 'Account' dropdown should no longer be visible.