### PR TITLE
Adds hsts header

### DIFF
--- a/backend/handlers/hsts_dev.go
+++ b/backend/handlers/hsts_dev.go
@@ -1,0 +1,11 @@
+// +build dev
+
+package handlers
+
+import "net/http"
+
+func (s *defaultServer) hstsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(rw, r)
+	})
+}

--- a/backend/handlers/hsts_prod.go
+++ b/backend/handlers/hsts_prod.go
@@ -7,7 +7,7 @@ import "net/http"
 func (s *defaultServer) hstsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if r.URL.Scheme == "https" || // If the url tells us https
-			r.TLS != nil && r.TLS.HandshakeComplete { // if the request is using tls
+			(r.TLS != nil && r.TLS.HandshakeComplete) { // if the request is using tls
 
 			rw.Header().Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
 

--- a/backend/handlers/hsts_prod.go
+++ b/backend/handlers/hsts_prod.go
@@ -1,0 +1,22 @@
+// +build !dev
+
+package handlers
+
+import "net/http"
+
+func (s *defaultServer) hstsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.URL.Scheme == "https" || // If the url tells us https
+			r.TLS != nil && r.TLS.HandshakeComplete { // if the request is using tls
+
+			rw.Header().Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
+
+			next.ServeHTTP(rw, r)
+			return
+		}
+
+		r.URL.Scheme = "https"
+
+		http.Redirect(rw, r, r.URL.String(), http.StatusMovedPermanently)
+	})
+}

--- a/backend/handlers/routes.go
+++ b/backend/handlers/routes.go
@@ -5,6 +5,7 @@ import (
 )
 
 func (s *defaultServer) routes() {
+	s.router.Use(s.hstsMiddleware)
 	s.router.Use(s.enableCors)
 	s.router.Use(s.enableCsrf)
 


### PR DESCRIPTION
Closes https://github.com/mtlynch/whatgotdone/issues/144

This pull request adds the HSTS header to the request by utilizing the Gorilla Mux middleware to ensure that all http requests on prod are redirected to https with a 301, and that all https request get the HSTS header.

Max age is set to 31536000 seconds, which is 1 year. I figured it might be a good baseline, although maybe it should be changed to 2 years.