### PR TITLE
Disabling host check in Vue dev mode

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  runtimeCompiler: true
+  runtimeCompiler: true,
+  devServer: {
+    disableHostCheck: true,
+  }
 }


### PR DESCRIPTION
This doesn't really do anything useful, and it inhibits useful dev scenarios like developing on a remote VM