### PR TITLE
Removing cron job deploy from Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,9 +124,6 @@ jobs:
       - run:
           name: Deploy to AppEngine
           command: gcloud --quiet app deploy --promote
-      - run:
-          name: Deploy cron jobs to AppEngine
-          command: gcloud --quiet app deploy cron.yaml --promote
 workflows:
   version: 2
   test-deploy:


### PR DESCRIPTION
It fails with bad permissions but works deploying locally.