### PR TITLE
Hide 'Post Update' button if the user is on the entry edit page

### DIFF
--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -36,6 +36,7 @@
           variant="success"
           v-b-toggle.nav-collapse
           :to="'/entry/edit/' + this.thisFriday"
+          v-if="!isOnEntryEditPage"
           >Post Update</b-button
         >
       </b-navbar-nav>
@@ -56,6 +57,9 @@ export default {
   computed: {
     username() {
       return this.$store.state.username;
+    },
+    isOnEntryEditPage() {
+      return this.$route.path.startsWith('/entry/edit/');
     },
   },
 };


### PR DESCRIPTION
It's confusing to show the user both a 'Publish' button and a 'Post Update' button, so hide 'Post Update' in the navbar if the user is already editing an update.

Fixes #404