### PR TITLE
Narrowing the last section of the home page

### DIFF
--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -80,12 +80,17 @@
       </div>
     </div>
 
-    <h2>Contact us</h2>
-    <p>
-      If you have questions or feature requests for What Got Done, we'd love to
-      speak to you. Send an email to
-      <a href="mailto:contact@whatgotdone.com">contact@whatgotdone.com</a>.
-    </p>
+    <div class="contact-us">
+      <h2>Contact us</h2>
+      <p>
+        If you have questions or feature requests for What Got Done, we'd love
+        to speak to you.
+      </p>
+      <p>
+        Send an email to
+        <a href="mailto:contact@whatgotdone.com">contact@whatgotdone.com</a>.
+      </p>
+    </div>
   </div>
 </template>
 
@@ -192,5 +197,11 @@ a {
 
 #example-freeform {
   border: 1px solid black;
+}
+
+@media (min-width: 768px) {
+  .contact-us {
+    max-width: 570px;
+  }
 }
 </style>


### PR DESCRIPTION
Narrowing the 'Contact Us' section of the home page so that it lines up a little better with text from the previous sections.

Fixes #402