### PR TITLE
Preventing break of the back button on login page

### DIFF
--- a/frontend/src/views/EditEntry.vue
+++ b/frontend/src/views/EditEntry.vue
@@ -122,7 +122,7 @@ export default {
   },
   created() {
     if (!this.username) {
-      this.$router.push('/login');
+      this.$router.replace('/login');
       return;
     }
     if (this.$route.params.date && isValidEntryDate(this.$route.params.date)) {

--- a/integration/cypress/integration/spec.js
+++ b/integration/cypress/integration/spec.js
@@ -43,6 +43,7 @@ it('clicking "Post Update" before authenticating prompts login', () => {
 
 it("back button should work if the user decides not to login/sign up", () => {
   cy.visit("/");
+  cy.get("nav .post-update").click();
 
   cy.location("pathname").should("eq", "/login");
 

--- a/integration/cypress/integration/spec.js
+++ b/integration/cypress/integration/spec.js
@@ -41,6 +41,16 @@ it('clicking "Post Update" before authenticating prompts login', () => {
   cy.location("pathname").should("eq", "/login");
 });
 
+it("back button should work if the user decides not to login/sign up", () => {
+  cy.visit("/");
+
+  cy.location("pathname").should("eq", "/login");
+
+  cy.go(-1);
+
+  cy.location("pathname").should("eq", "/");
+});
+
 it("reaction buttons should not appear when the post is missing", () => {
   cy.visit("/staging_jimmy/2000-01-07");
 


### PR DESCRIPTION
The edit entry page was redirecting the user to /login, but this was breaking the back button. Fix is to just do .replace() instead of .push()

Fixes #405