### PR TITLE
Adjusting UserKit widget params to allow exiting the modal

### DIFF
--- a/frontend/src/controllers/UserKit.js
+++ b/frontend/src/controllers/UserKit.js
@@ -42,7 +42,6 @@ function loadWidgetJs(appId) {
   userKitScript.setAttribute('src', widgetJsUrl);
   userKitScript.setAttribute('data-app-id', appId);
   userKitScript.setAttribute('data-show-on-load', 'login');
-  userKitScript.setAttribute('data-login-dismiss', 'false');
   document.head.appendChild(userKitScript);
 }
 

--- a/integration/cypress/integration/spec.js
+++ b/integration/cypress/integration/spec.js
@@ -52,20 +52,6 @@ it("back button should work if the user decides not to login/sign up", () => {
   cy.location("pathname").should("eq", "/");
 });
 
-it("login widget disappears when user clicks outside of modal window", () => {
-  cy.visit("/");
-  cy.get("nav .post-update").click();
-
-  // Modal login widget should appear.
-  cy.get(".vex .vex-dialog-message").should("contain", "Login");
-
-  // Click outside the modal login widget.
-  cy.get(".navbar .navbar-brand").click({ force: true });
-
-  // Modal login widget should disappear.
-  cy.get(".vex .vex-content").should("not.exist");
-});
-
 it("reaction buttons should not appear when the post is missing", () => {
   cy.visit("/staging_jimmy/2000-01-07");
 

--- a/integration/cypress/integration/spec.js
+++ b/integration/cypress/integration/spec.js
@@ -56,7 +56,8 @@ it("login widget disappears when user clicks outside of modal window", () => {
   cy.visit("/");
   cy.get("nav .post-update").click();
 
-  cy.location("pathname").should("eq", "/login");
+  // Modal login widget should appear.
+  cy.get(".vex .vex-dialog-message").should("contain", "Login");
 
   // Click outside the modal login widget.
   cy.get(".navbar .navbar-brand").click({ force: true });

--- a/integration/cypress/integration/spec.js
+++ b/integration/cypress/integration/spec.js
@@ -52,6 +52,19 @@ it("back button should work if the user decides not to login/sign up", () => {
   cy.location("pathname").should("eq", "/");
 });
 
+it("login widget disappears when user clicks outside of modal window", () => {
+  cy.visit("/");
+  cy.get("nav .post-update").click();
+
+  cy.location("pathname").should("eq", "/login");
+
+  // Click outside the modal login widget.
+  cy.get(".navbar .navbar-brand").click({ force: true });
+
+  // Modal login widget should disappear.
+  cy.get(".vex .vex-content").should("not.exist");
+});
+
 it("reaction buttons should not appear when the post is missing", () => {
   cy.visit("/staging_jimmy/2000-01-07");
 


### PR DESCRIPTION
Per @dtq's comment on #406, we actually want to remove the data-login-dismiss = false line because it's making the login window un-dismissable.

Fixes #406