### PR TITLE
Adding target="_blank" to Markdown link

### DIFF
--- a/frontend/src/views/EditEntry.vue
+++ b/frontend/src/views/EditEntry.vue
@@ -17,7 +17,9 @@
       ></textarea-autosize>
       <p>
         (You can use
-        <a href="https://www.markdownguide.org/cheat-sheet/">Markdown</a>)
+        <a href="https://www.markdownguide.org/cheat-sheet/" target="_blank"
+          >Markdown</a
+        >)
       </p>
       <div class="d-flex justify-content-end">
         <button


### PR DESCRIPTION
Otherwise, we risk unexpectedly taking the user away from their page mid-edit and losing it before the draft saves.