### PR TITLE
Adding unsafe-inline to style-src

### DIFF
--- a/backend/handlers/csp_common.go
+++ b/backend/handlers/csp_common.go
@@ -25,6 +25,8 @@ func contentSecurityPolicy() string {
 			"https://widget.userkit.io/css/",
 			"https://fonts.googleapis.com",
 			"https://fonts.gstatic.com",
+			// Google auth requires this, and I can't figure out any way to avoid it.
+			"'unsafe-inline'",
 		},
 		"frame-src": []string{
 			// URLs for /login route (UserKit)

--- a/backend/handlers/csp_dev.go
+++ b/backend/handlers/csp_dev.go
@@ -11,5 +11,5 @@ func extraScriptSrcSources() []string {
 }
 
 func extraStyleSrcSources() []string {
-	return []string{"'unsafe-inline'"}
+	return []string{}
 }


### PR DESCRIPTION
Workaround because we can't seem to make Google Auth sign in work otherwise: https://gist.github.com/mtlynch/f364b61a215bd1cf9ab7ac61d70a47f6