### PR TITLE
Adding handlers wildcard to app.yaml to ensure HTTPS always

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,3 +3,8 @@ runtime: go113
 includes:
   - env_variables.yaml
 main: ./backend
+handlers:
+  - url: /.*
+    script: auto
+    secure: always
+    redirect_http_response_code: 301


### PR DESCRIPTION
Adding a wildcard handler to app.yaml to ensure that What Got Done always redirects clients to HTTPS in production.