### PR TITLE
Bringing back reactions in author mode

### DIFF
--- a/frontend/src/views/ViewEntry.vue
+++ b/frontend/src/views/ViewEntry.vue
@@ -30,7 +30,7 @@
     <p v-if="backendError" class="error">
       Failed to connect to backend: {{ backendError }}
     </p>
-    <div class="author-controls" v-if="canEdit">
+    <div class="author-controls mb-4" v-if="canEdit">
       <b-button
         :href="twitterShareUrl"
         title="Share on Twitter"
@@ -49,7 +49,7 @@
     <Reactions
       :entryAuthor="entryAuthor"
       :entryDate="entryDate"
-      v-if="currentEntry && !canEdit"
+      v-if="currentEntry"
     />
   </div>
 </template>


### PR DESCRIPTION
In #423, I meant to hide the reaction buttons when the author is viewing their own entry, but I accidentally hid the reaction buttons *and* the reactions themselves.

This change brings back both the reaction buttons and the reaction history until I find a cleaner way to hide the buttons in author mode.