### PR TITLE
Disabled "More Entries" button when get request is in progress

### DIFF
--- a/frontend/src/controllers/Recent.js
+++ b/frontend/src/controllers/Recent.js
@@ -10,11 +10,12 @@ export function refreshRecent() {
   });
 }
 
-export function extendRecent() {
+export function extendRecent(callback) {
   let recentEntries = store.state.recentEntries;
   getRecent(recentEntries.length, updateSize, newEntries => {
     recentEntries.push(...newEntries);
     store.commit('setRecent', recentEntries);
+    callback();
   });
 }
 

--- a/frontend/src/views/Recent.vue
+++ b/frontend/src/views/Recent.vue
@@ -3,13 +3,18 @@
     <h1>Recent Entries</h1>
     <p>Check out what other users got done this week:</p>
 
-    <PartialJournal v-bind:key="item.key" v-bind:entry="item" v-for="item in recentEntries" />
+    <PartialJournal
+      v-bind:key="item.key"
+      v-bind:entry="item"
+      v-for="item in recentEntries"
+    />
 
     <b-button
       variant="secondary"
       v-bind:disabled="requestInProgress"
       v-on:click="onLoadMore"
-    >More Entries</b-button>
+      >More Entries</b-button
+    >
   </div>
 </template>
 

--- a/frontend/src/views/Recent.vue
+++ b/frontend/src/views/Recent.vue
@@ -3,15 +3,13 @@
     <h1>Recent Entries</h1>
     <p>Check out what other users got done this week:</p>
 
-    <PartialJournal
-      v-bind:key="item.key"
-      v-bind:entry="item"
-      v-for="item in recentEntries"
-    />
+    <PartialJournal v-bind:key="item.key" v-bind:entry="item" v-for="item in recentEntries" />
 
-    <b-button variant="secondary" v-on:click="onLoadMore"
-      >More Entries</b-button
-    >
+    <b-button
+      variant="secondary"
+      v-bind:disabled="requestInProgress"
+      v-on:click="onLoadMore"
+    >More Entries</b-button>
   </div>
 </template>
 
@@ -25,6 +23,11 @@ export default {
   components: {
     PartialJournal,
   },
+  data() {
+    return {
+      requestInProgress: false,
+    };
+  },
   computed: {
     recentEntries() {
       return this.$store.state.recentEntries;
@@ -32,7 +35,13 @@ export default {
   },
   methods: {
     onLoadMore() {
-      return extendRecent();
+      /**
+       * To prevent muliple click, disable button while api call is in progress
+       */
+      this.requestInProgress = true; // Set the flag true before fetch call
+      return extendRecent(() => {
+        this.requestInProgress = false; // Reset the flag in callback
+      });
     },
   },
   created() {


### PR DESCRIPTION
Added code to prevent duplicate user clicks when more entries get request is in progress. 
Button will be disabled when user hit More entries button and it will be enabled when get request is completed. 