### PR TITLE
Disabling video compression

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,5 +1,6 @@
 {
   "pluginsFile": false,
   "supportFile": false,
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 10000,
+  "videoCompression": false
 }

--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -1,5 +1,6 @@
 {
   "pluginsFile": false,
   "supportFile": false,
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 10000,
+  "videoCompression": false
 }


### PR DESCRIPTION
It just adds extra time to the build and we don't care that much about saving file size