### PR TITLE
Refactoring OPTIONS handlers of backend router

### DIFF
--- a/backend/handlers/draft.go
+++ b/backend/handlers/draft.go
@@ -10,10 +10,6 @@ import (
 	"github.com/mtlynch/whatgotdone/backend/types"
 )
 
-func (s defaultServer) draftOptions() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {}
-}
-
 func (s defaultServer) draftGet() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		username, err := s.loggedInUser(r)

--- a/backend/handlers/entries.go
+++ b/backend/handlers/entries.go
@@ -32,10 +32,6 @@ func (s *defaultServer) entriesGet() http.HandlerFunc {
 	}
 }
 
-func (s *defaultServer) entryOptions() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {}
-}
-
 // entryPost handles HTTP POST requests for users to create new What Got
 // Done updates. The updates can be new versions of previously published
 // updates (in which case, we'll update the existing entries in the datastore)

--- a/backend/handlers/google_analytics.go
+++ b/backend/handlers/google_analytics.go
@@ -18,10 +18,6 @@ type pageViewResponse struct {
 	Views int    `json:"views"`
 }
 
-func (s *defaultServer) pageViewsOptions() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {}
-}
-
 func (s defaultServer) pageViewsGet() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Query().Get("path")

--- a/backend/handlers/logout.go
+++ b/backend/handlers/logout.go
@@ -5,10 +5,6 @@ import (
 	"time"
 )
 
-func (s defaultServer) logoutOptions() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {}
-}
-
 func (s defaultServer) logoutPost() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		http.SetCookie(w, &http.Cookie{

--- a/backend/handlers/project.go
+++ b/backend/handlers/project.go
@@ -59,7 +59,3 @@ func (s *defaultServer) projectGet() http.HandlerFunc {
 		}
 	}
 }
-
-func (s *defaultServer) projectOptions() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {}
-}

--- a/backend/handlers/reactions.go
+++ b/backend/handlers/reactions.go
@@ -11,10 +11,6 @@ import (
 	"github.com/mtlynch/whatgotdone/backend/types"
 )
 
-func (s defaultServer) reactionsOptions() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {}
-}
-
 func (s defaultServer) reactionsGet() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		date, err := dateFromRequestPath(r)

--- a/backend/handlers/routes.go
+++ b/backend/handlers/routes.go
@@ -4,30 +4,36 @@ import (
 	"net/http"
 )
 
+// A no-op function that tells the router to accept the OPTIONS method for a
+// particular route.
+func allowOptions() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {}
+}
+
 func (s *defaultServer) routes() {
 	s.router.Use(s.enableCors)
 	s.router.Use(s.enableCsrf)
 
 	// Handle routes that require backend logic.
 	s.router.HandleFunc("/api/entries/{username}", s.entriesGet()).Methods(http.MethodGet)
-	s.router.HandleFunc("/api/entries/{username}/project/{project}", s.projectOptions()).Methods(http.MethodOptions)
+	s.router.HandleFunc("/api/entries/{username}/project/{project}", allowOptions()).Methods(http.MethodOptions)
 	s.router.HandleFunc("/api/entries/{username}/project/{project}", s.projectGet()).Methods(http.MethodGet)
-	s.router.HandleFunc("/api/entry/{date}", s.entryOptions()).Methods(http.MethodOptions)
+	s.router.HandleFunc("/api/entry/{date}", allowOptions()).Methods(http.MethodOptions)
 	s.router.HandleFunc("/api/entry/{date}", s.entryPost()).Methods(http.MethodPost)
-	s.router.HandleFunc("/api/draft/{date}", s.draftOptions()).Methods(http.MethodOptions)
+	s.router.HandleFunc("/api/draft/{date}", allowOptions()).Methods(http.MethodOptions)
 	s.router.HandleFunc("/api/draft/{date}", s.draftGet()).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/draft/{date}", s.draftPost()).Methods(http.MethodPost)
-	s.router.HandleFunc("/api/pageViews", s.pageViewsOptions()).Methods(http.MethodOptions)
+	s.router.HandleFunc("/api/pageViews", allowOptions()).Methods(http.MethodOptions)
 	s.router.HandleFunc("/api/pageViews", s.pageViewsGet()).Methods(http.MethodGet)
-	s.router.HandleFunc("/api/reactions/entry/{username}/{date}", s.reactionsOptions()).Methods(http.MethodOptions)
+	s.router.HandleFunc("/api/reactions/entry/{username}/{date}", allowOptions()).Methods(http.MethodOptions)
 	s.router.HandleFunc("/api/reactions/entry/{username}/{date}", s.reactionsGet()).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/reactions/entry/{username}/{date}", s.reactionsPost()).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/recentEntries", s.recentEntriesGet()).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/user/me", s.userMeGet()).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/user/{username}", s.userGet()).Methods(http.MethodGet)
-	s.router.HandleFunc("/api/user", s.userOptions()).Methods(http.MethodOptions)
+	s.router.HandleFunc("/api/user", allowOptions()).Methods(http.MethodOptions)
 	s.router.HandleFunc("/api/user", s.userPost()).Methods(http.MethodPost)
-	s.router.HandleFunc("/api/logout", s.logoutOptions()).Methods(http.MethodOptions)
+	s.router.HandleFunc("/api/logout", allowOptions()).Methods(http.MethodOptions)
 	s.router.HandleFunc("/api/logout", s.logoutPost()).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/tasks/refreshGoogleAnalytics", s.refreshGoogleAnalytics()).Methods(http.MethodGet)
 

--- a/backend/handlers/user.go
+++ b/backend/handlers/user.go
@@ -11,10 +11,6 @@ import (
 	"github.com/mtlynch/whatgotdone/backend/types"
 )
 
-func (s defaultServer) userOptions() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {}
-}
-
 func (s defaultServer) userGet() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		username, err := usernameFromRequestPath(r)


### PR DESCRIPTION
I should have thought of this earlier, but we don't need to independently define no-op functions for every route.