### PR TITLE
Removing vue-axios

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14244,11 +14244,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
       "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
-    "vue-axios": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/vue-axios/-/vue-axios-2.1.5.tgz",
-      "integrity": "sha512-th5xVbInVoyIoe+qY+9GCflEVezxAvztD4xpFF39SRQYqpoKD2qkmX8yv08jJG9a2SgNOCjirjJGSwg/wTrbmA=="
-    },
     "vue-eslint-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
     "core-js": "^2.6.11",
     "lodash": "^4.17.15",
     "vue": "^2.6.11",
-    "vue-axios": "^2.1.5",
     "vue-gtag": "^1.1.2",
     "vue-markdown": "^2.2.4",
     "vue-moment": "^4.0.0",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,5 @@
 import Vue from 'vue';
-import axios from 'axios';
 import VueGtag from 'vue-gtag';
-import VueAxios from 'vue-axios';
 import VueMoment from 'vue-moment';
 import BootstrapVue from 'bootstrap-vue';
 import {config, library} from '@fortawesome/fontawesome-svg-core';
@@ -16,7 +14,6 @@ import 'bootswatch/dist/superhero/bootstrap.min.css';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
 
 Vue.config.productionTip = false;
-Vue.use(VueAxios, axios);
 Vue.use(BootstrapVue);
 
 // Need to prevent FontAwesome from auto-adding CSS otherwise it violates


### PR DESCRIPTION
Now that we do all axios calls in controllers, we no longer need vue-axios