### PR TITLE
Deleting e2e tests that are redundant to integration tests

### DIFF
--- a/e2e/cypress/integration/spec.js
+++ b/e2e/cypress/integration/spec.js
@@ -6,26 +6,10 @@ Cypress.Commands.add("login", (username, options = {}) => {
   cy.get("form").submit();
 });
 
-it("loads the homepage", () => {
-  cy.visit("/");
-
-  cy.get("h1").should("contain", "What did you get done this week?");
-});
-
 it("views recent posts", () => {
   cy.visit("/recent");
 
   cy.get("div.journal").should("contain", "staging_jimmy's update");
-});
-
-it('clicking "Post Update" before authenticating prompts login', () => {
-  cy.visit("/");
-
-  cy.get("nav .account-dropdown").should("not.exist");
-
-  cy.get("nav .post-update").click();
-
-  cy.location("pathname").should("eq", "/login");
 });
 
 it("reacting to an entry before authenticating prompts login", () => {
@@ -51,34 +35,6 @@ it("renders the date correctly", () => {
   });
 });
 
-it("reaction buttons should not appear when the post is missing", () => {
-  cy.visit("/staging_jimmy/2000-01-07");
-
-  cy.get(".reaction-buttons").should("not.exist");
-});
-
-it("logs in and posts an update", () => {
-  cy.server();
-  cy.route("/api/draft/*").as("getDraft");
-
-  cy.login("staging_jimmy");
-
-  cy.location("pathname").should("include", "/entry/edit");
-
-  // Wait for page to pull down any previous entry.
-  cy.wait("@getDraft");
-
-  const entryText = "Posted an update at " + new Date().toISOString();
-
-  cy.get(".journal-markdown")
-    .clear()
-    .type(entryText);
-  cy.get("form").submit();
-
-  cy.location("pathname").should("include", "/staging_jimmy/");
-  cy.get(".journal-body").should("contain", entryText);
-});
-
 it("logs in and posts an empty update (deleting the update)", () => {
   cy.server();
   cy.route("/api/draft/*").as("getDraft");
@@ -95,46 +51,6 @@ it("logs in and posts an empty update (deleting the update)", () => {
 
   cy.location("pathname").should("include", "/staging_jimmy/");
   cy.get(".missing-entry").should("be.visible");
-});
-
-it("logs in and saves a draft", () => {
-  cy.server();
-  cy.route("GET", "/api/draft/*").as("getDraft");
-  cy.route("POST", "/api/draft/*").as("postDraft");
-
-  cy.login("staging_jimmy");
-
-  cy.location("pathname").should("include", "/entry/edit");
-
-  // Wait for page to pull down any previous entry.
-  cy.wait("@getDraft");
-
-  const entryText = "Saved a private draft at " + new Date().toISOString();
-
-  cy.get(".journal-markdown")
-    .clear()
-    .type(entryText);
-  cy.get(".save-draft").click();
-
-  // Wait for "save draft" operation to complete.
-  cy.wait("@postDraft");
-
-  // User should stay on the same page after saving a draft.
-  cy.location("pathname").should("include", "/entry/edit");
-
-  cy.visit("/recent");
-
-  // Private drafts should not appear on the recent page
-  cy.get("#app").should("not.contain", entryText);
-});
-
-it("logs in and views profile", () => {
-  cy.login("staging_jimmy");
-
-  cy.get(".account-dropdown").click();
-  cy.get(".profile-link a").click();
-
-  cy.location("pathname").should("eq", "/staging_jimmy");
 });
 
 it("logs in and reacts to an entry", () => {
@@ -192,59 +108,4 @@ it("reacting to an entry prompts login and redirects back to the entry", () => {
   cy.wait("@postUserKitLogin");
 
   cy.location("pathname").should("eq", "/staging_jimmy/2019-06-28");
-});
-
-it("logs in and signs out", () => {
-  cy.server();
-  cy.route("/api/user/me").as("getUsername");
-  cy.login("staging_jimmy");
-
-  cy.location("pathname").should("include", "/entry/edit");
-  cy.wait("@getUsername");
-
-  cy.get(".account-dropdown").click();
-  cy.get(".sign-out-link a").click();
-  cy.location("pathname").should("eq", "/");
-
-  cy.get("nav .account-dropdown").should("not.exist");
-});
-
-it("views a non-existing user profile with empty information", () => {
-  cy.visit("/nonExistentUser");
-  cy.get(".no-bio-message").should("be.visible");
-  cy.get(".no-entries-message").should("be.visible");
-});
-
-it("logs in updates profile", () => {
-  cy.server();
-  cy.route("/api/user/staging_jimmy").as("getUserProfile");
-
-  cy.login("staging_jimmy");
-
-  cy.location("pathname").should("include", "/entry/edit");
-
-  cy.visit("/staging_jimmy");
-  cy.get(".edit-btn").click();
-
-  // Wait for page to pull down existing profile.
-  cy.wait("@getUserProfile");
-
-  cy.get("#user-bio")
-    .clear()
-    .type("Hello, my name is staging_jimmy!");
-
-  cy.get("#email-address")
-    .clear()
-    .type("staging_jimmy@example.com");
-
-  cy.get("#twitter-handle")
-    .clear()
-    .type("jack");
-
-  cy.get("#save-profile").click();
-  cy.location("pathname").should("eq", "/staging_jimmy");
-
-  cy.get(".user-bio").should("contain", "Hello, my name is staging_jimmy!");
-  cy.get(".email-address").should("contain", "staging_jimmy@example.com");
-  cy.get(".twitter-handle").should("contain", "jack");
 });


### PR DESCRIPTION
We're getting rid of e2e tests a they're either redundant or depend on external state. This is the first wave of cuts to get rid of tests that are covered in ./integration.