### PR TITLE
Actually clear login state

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,8 +24,10 @@ export default {
   },
   created() {
     loadUserKit(process.env.VUE_APP_USERKIT_APP_ID).then(userKit => {
-      if (userKit.isLoggedIn() !== true) {
+      if (userKit.isLoggedIn() === true) {
         updateLoginState();
+      } else {
+        this.$store.commit('clearLoginState');
       }
     });
     getRecent(/*start=*/ 0).then(recentEntries => {


### PR DESCRIPTION
If users is not logged in to UserKit, we should clear the login state. Otherwise, we should refresh the login details from the server.