### PR TITLE
Switching to a Go-native representation of time for reactions

### DIFF
--- a/backend/datastore/firestore/draft.go
+++ b/backend/datastore/firestore/draft.go
@@ -38,8 +38,8 @@ func (c client) InsertDraft(username string, j types.JournalEntry) error {
 	log.Printf("adding new draft for %s: %+v", username, j)
 	// Create a User document so that its children appear in Firestore console.
 	c.firestoreClient.Collection(draftsRootKey).Doc(username).Set(c.ctx, userDocument{
-		Username:     username,
-		LastModified: j.LastModified,
+		Username:         username,
+		LastModifiedTime: j.LastModifiedTime,
 	})
 	_, err := c.firestoreClient.Collection(draftsRootKey).Doc(username).Collection(perUserDraftsKey).Doc(j.Date).Set(c.ctx, j)
 	return err

--- a/backend/datastore/firestore/entries.go
+++ b/backend/datastore/firestore/entries.go
@@ -61,8 +61,8 @@ func (c client) InsertEntry(username string, j types.JournalEntry) error {
 	log.Printf("adding new entry for %s: %+v", username, j)
 	// Create a User document so that its children appear in Firestore console.
 	c.firestoreClient.Collection(entriesRootKey).Doc(username).Set(c.ctx, userDocument{
-		Username:     username,
-		LastModified: j.LastModified,
+		Username:         username,
+		LastModifiedTime: j.LastModifiedTime,
 	})
 	_, err := c.firestoreClient.Collection(entriesRootKey).Doc(username).Collection(perUserEntriesKey).Doc(j.Date).Set(c.ctx, j)
 	return err

--- a/backend/datastore/firestore/firestore.go
+++ b/backend/datastore/firestore/firestore.go
@@ -21,8 +21,8 @@ type (
 	}
 
 	userDocument struct {
-		Username     string `firestore:"username,omitempty"`
-		LastModified string `firestore:"lastModified,omitempty"`
+		Username         string    `firestore:"username,omitempty"`
+		LastModifiedTime time.Time `firestore:"lastModifiedTime,omitempty"`
 	}
 
 	reactionsDocument struct {
@@ -40,8 +40,8 @@ type (
 	}
 
 	followDocument struct {
-		Follower     string    `firestore:"follower"`
-		LastModified time.Time `firestore:"lastModified"`
+		Follower         string    `firestore:"follower"`
+		LastModifiedTime time.Time `firestore:"lastModifiedTime"`
 	}
 )
 

--- a/backend/datastore/firestore/follow.go
+++ b/backend/datastore/firestore/follow.go
@@ -15,8 +15,8 @@ import (
 func (c client) InsertFollow(leader, follower string) error {
 	// Create a followDocument so that its children appear in Firestore console.
 	c.firestoreClient.Collection(followingRootKey).Doc(follower).Set(c.ctx, followDocument{
-		Follower:     follower,
-		LastModified: time.Now().UTC(),
+		Follower:         follower,
+		LastModifiedTime: time.Now().UTC(),
 	})
 	f := types.Follow{
 		Leader:   leader,

--- a/backend/datastore/firestore/reaction.go
+++ b/backend/datastore/firestore/reaction.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"log"
+	"time"
 
 	"google.golang.org/api/iterator"
 
@@ -35,6 +36,8 @@ func (c client) AddReaction(entryAuthor string, entryDate string, reaction types
 		entryAuthor: entryAuthor,
 		entryDate:   entryDate,
 	})
+
+	reaction.CreationTime = time.Now()
 	key := getEntryReactionsKey(entryAuthor, entryDate)
 	log.Printf("adding reaction to datastore: %s -> %+v", key, reaction)
 	_, err := c.firestoreClient.Collection(reactionsRootKey).Doc(key).Collection(perUserReactionsKey).Doc(reaction.Username).Set(c.ctx, reaction)

--- a/backend/datastore/firestore/reaction.go
+++ b/backend/datastore/firestore/reaction.go
@@ -2,7 +2,6 @@ package firestore
 
 import (
 	"log"
-	"time"
 
 	"google.golang.org/api/iterator"
 
@@ -37,7 +36,6 @@ func (c client) AddReaction(entryAuthor string, entryDate string, reaction types
 		entryDate:   entryDate,
 	})
 
-	reaction.CreationTime = time.Now()
 	key := getEntryReactionsKey(entryAuthor, entryDate)
 	log.Printf("adding reaction to datastore: %s -> %+v", key, reaction)
 	_, err := c.firestoreClient.Collection(reactionsRootKey).Doc(key).Collection(perUserReactionsKey).Doc(reaction.Username).Set(c.ctx, reaction)

--- a/backend/datastore/firestore/reaction.go
+++ b/backend/datastore/firestore/reaction.go
@@ -35,7 +35,6 @@ func (c client) AddReaction(entryAuthor string, entryDate string, reaction types
 		entryAuthor: entryAuthor,
 		entryDate:   entryDate,
 	})
-
 	key := getEntryReactionsKey(entryAuthor, entryDate)
 	log.Printf("adding reaction to datastore: %s -> %+v", key, reaction)
 	_, err := c.firestoreClient.Collection(reactionsRootKey).Doc(key).Collection(perUserReactionsKey).Doc(reaction.Username).Set(c.ctx, reaction)

--- a/backend/handlers/draft.go
+++ b/backend/handlers/draft.go
@@ -80,9 +80,9 @@ func (s defaultServer) draftPost() http.HandlerFunc {
 		}
 
 		j := types.JournalEntry{
-			Date:         date,
-			LastModified: time.Now().Format(time.RFC3339),
-			Markdown:     t.EntryContent,
+			Date:             date,
+			LastModifiedTime: time.Now(),
+			Markdown:         t.EntryContent,
 		}
 		err = s.datastore.InsertDraft(username, j)
 		if err != nil {

--- a/backend/handlers/draft_test.go
+++ b/backend/handlers/draft_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDraftHandlerWhenUserIsNotLoggedIn(t *testing.T) {
 	drafts := []types.JournalEntry{
-		types.JournalEntry{Date: "2019-04-19", LastModified: "2019-04-19", Markdown: "Drove to the zoo"},
+		types.JournalEntry{Date: "2019-04-19", LastModifiedTime: "2019-04-19", Markdown: "Drove to the zoo"},
 	}
 	ds := mockDatastore{
 		journalDrafts: drafts,
@@ -43,7 +43,7 @@ func TestDraftHandlerWhenUserIsNotLoggedIn(t *testing.T) {
 
 func TestDraftHandlerWhenUserTokenIsInvalid(t *testing.T) {
 	drafts := []types.JournalEntry{
-		types.JournalEntry{Date: "2019-04-19", LastModified: "2019-04-19", Markdown: "Drove to the zoo"},
+		types.JournalEntry{Date: "2019-04-19", LastModifiedTime: mustParseTime("2019-04-19"), Markdown: "Drove to the zoo"},
 	}
 	ds := mockDatastore{
 		journalDrafts: drafts,
@@ -78,7 +78,7 @@ func TestDraftHandlerWhenUserTokenIsInvalid(t *testing.T) {
 
 func TestDraftHandlerWhenDateMatches(t *testing.T) {
 	drafts := []types.JournalEntry{
-		types.JournalEntry{Date: "2019-04-19", LastModified: "2019-04-19", Markdown: "Drove to the zoo"},
+		types.JournalEntry{Date: "2019-04-19", LastModifiedTime: mustParseTime("2019-04-19"), Markdown: "Drove to the zoo"},
 	}
 	ds := mockDatastore{
 		journalDrafts: drafts,

--- a/backend/handlers/entries.go
+++ b/backend/handlers/entries.go
@@ -65,9 +65,9 @@ func (s *defaultServer) entryPost() http.HandlerFunc {
 		}
 
 		j := types.JournalEntry{
-			Date:         date,
-			LastModified: time.Now().Format(time.RFC3339),
-			Markdown:     t.EntryContent,
+			Date:             date,
+			LastModifiedTime: time.Now(),
+			Markdown:         t.EntryContent,
 		}
 
 		err = s.datastore.InsertDraft(username, j)

--- a/backend/handlers/entries_test.go
+++ b/backend/handlers/entries_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestEntriesHandler(t *testing.T) {
 	entries := []types.JournalEntry{
-		types.JournalEntry{Date: "2019-03-22", LastModified: "2019-03-24", Markdown: "Ate some crackers"},
-		types.JournalEntry{Date: "2019-03-15", LastModified: "2019-03-15", Markdown: "Took a nap"},
-		types.JournalEntry{Date: "2019-03-08", LastModified: "2019-03-09", Markdown: "Watched the movie *The Royal Tenenbaums*."},
+		types.JournalEntry{Date: "2019-03-22", LastModifiedTime: mustParseTime("2019-03-24"), Markdown: "Ate some crackers"},
+		types.JournalEntry{Date: "2019-03-15", LastModifiedTime: mustParseTime("2019-03-15"), Markdown: "Took a nap"},
+		types.JournalEntry{Date: "2019-03-08", LastModifiedTime: mustParseTime("2019-03-09"), Markdown: "Watched the movie *The Royal Tenenbaums*."},
 	}
 	ds := mockDatastore{
 		journalEntries: entries,

--- a/backend/handlers/google_analytics.go
+++ b/backend/handlers/google_analytics.go
@@ -73,11 +73,7 @@ func (s defaultServer) wasEntryPublishedRecently(username, entryDate string) boo
 	if err != nil {
 		return false
 	}
-	t, err := time.Parse(time.RFC3339, entry.LastModified)
-	if err != nil {
-		return false
-	}
-	return time.Now().Sub(t).Minutes() < 15
+	return time.Now().Sub(entry.LastModifiedTime).Minutes() < 15
 }
 
 func (s *defaultServer) refreshGoogleAnalytics() http.HandlerFunc {

--- a/backend/handlers/reactions.go
+++ b/backend/handlers/reactions.go
@@ -83,9 +83,9 @@ func (s defaultServer) reactionsPost() http.HandlerFunc {
 		}
 
 		reaction := types.Reaction{
-			Username:  username,
-			Timestamp: time.Now().Format(time.RFC3339),
-			Symbol:    reactionSymbol,
+			Username:     username,
+			CreationTime: time.Now(),
+			Symbol:       reactionSymbol,
 		}
 		err = s.datastore.AddReaction(entryAuthor, entryDate, reaction)
 		if err != nil {

--- a/backend/handlers/reactions_test.go
+++ b/backend/handlers/reactions_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/mtlynch/whatgotdone/backend/types"
@@ -27,6 +28,14 @@ func dummyCsrfMiddleware() httpMiddlewareHandler {
 	return func(h http.Handler) http.Handler {
 		return h
 	}
+}
+
+func mustParseReactionCreationTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }
 
 func TestReactionsGetWhenEntryHasNoReactions(t *testing.T) {
@@ -66,8 +75,16 @@ func TestReactionsGetWhenEntryHasNoReactions(t *testing.T) {
 
 func TestReactionsGetWhenEntryHasTwoReactions(t *testing.T) {
 	reactions := []types.Reaction{
-		types.Reaction{Username: "dummyUserA", Symbol: "🎉", Timestamp: "2019-07-09T14:56:29-04:00"},
-		types.Reaction{Username: "dummyUserB", Symbol: "👍", Timestamp: "2019-07-09T11:57:02-04:00"},
+		{
+			Username:     "dummyUserA",
+			Symbol:       "🎉",
+			CreationTime: mustParseReactionCreationTime("2019-07-09T14:56:29-04:00"),
+		},
+		{
+			Username:     "dummyUserB",
+			Symbol:       "👍",
+			CreationTime: mustParseReactionCreationTime("2019-07-09T11:57:02-04:00"),
+		},
 	}
 	ds := mockDatastore{
 		reactions: reactions,

--- a/backend/handlers/recent_entries.go
+++ b/backend/handlers/recent_entries.go
@@ -15,8 +15,8 @@ type entryPublic struct {
 	Date   string `json:"date"`
 	// Skip JSON serialization for lastModified as clients don't need this field,
 	// but we need it internally for sorting lists of entries.
-	lastModified string
-	Markdown     string `json:"markdown"`
+	lastModifiedTime string
+	Markdown         string `json:"markdown"`
 }
 
 type entriesPublic []entryPublic
@@ -56,10 +56,10 @@ func (s *defaultServer) recentEntriesGet() http.HandlerFunc {
 					continue
 				}
 				entries = append(entries, entryPublic{
-					Author:       username,
-					Date:         entry.Date,
-					lastModified: entry.LastModified,
-					Markdown:     entry.Markdown,
+					Author:           username,
+					Date:             entry.Date,
+					lastModifiedTime: entry.LastModifiedTime,
+					Markdown:         entry.Markdown,
 				})
 			}
 		}
@@ -105,10 +105,10 @@ func (s *defaultServer) entriesFollowingGet() http.HandlerFunc {
 			}
 			for _, entry := range userEntries {
 				entries = append(entries, entryPublic{
-					Author:       followedUsername,
-					Date:         entry.Date,
-					lastModified: entry.LastModified,
-					Markdown:     entry.Markdown,
+					Author:           followedUsername,
+					Date:             entry.Date,
+					lastModifiedTime: entry.LastModifiedTime,
+					Markdown:         entry.Markdown,
 				})
 			}
 		}

--- a/backend/handlers/recent_entries_test.go
+++ b/backend/handlers/recent_entries_test.go
@@ -15,13 +15,13 @@ import (
 
 func TestRecentEntriesHandlerSortsByDateThenByModifedTimeInDescendingOrder(t *testing.T) {
 	entries := []types.JournalEntry{
-		types.JournalEntry{Date: "2019-05-24", LastModified: "2019-05-24T00:00:00.000Z", Markdown: "Rode the bus and saw a movie about ghosts"},
-		types.JournalEntry{Date: "2019-05-24", LastModified: "2019-05-23T00:00:00.000Z", Markdown: "Ate some crackers in a bathtub"},
-		types.JournalEntry{Date: "2019-05-17", LastModified: "2019-05-17T12:00:00.000Z", Markdown: "Saw a movie about French vanilla"},
-		types.JournalEntry{Date: "2019-05-24", LastModified: "2019-05-25T00:00:00.000Z", Markdown: "Read a book about the history of cheese"},
-		types.JournalEntry{Date: "2019-05-24", LastModified: "2019-05-25T22:00:00.000Z", Markdown: "Read a pamphlet from The Cat Society"},
-		types.JournalEntry{Date: "2019-05-24", LastModified: "2019-05-25T06:00:00.000Z", Markdown: "Read the news today... Oh boy!"},
-		types.JournalEntry{Date: "2019-05-17", LastModified: "2019-05-16T00:00:00.000Z", Markdown: "Took a nap and dreamed about chocolate"},
+		types.JournalEntry{Date: "2019-05-24", LastModifiedTime: mustParseTime("2019-05-24T00:00:00.000Z"), Markdown: "Rode the bus and saw a movie about ghosts"},
+		types.JournalEntry{Date: "2019-05-24", LastModifiedTime: mustParseTime("2019-05-23T00:00:00.000Z"), Markdown: "Ate some crackers in a bathtub"},
+		types.JournalEntry{Date: "2019-05-17", LastModifiedTime: mustParseTime("2019-05-17T12:00:00.000Z"), Markdown: "Saw a movie about French vanilla"},
+		types.JournalEntry{Date: "2019-05-24", LastModifiedTime: mustParseTime("2019-05-25T00:00:00.000Z"), Markdown: "Read a book about the history of cheese"},
+		types.JournalEntry{Date: "2019-05-24", LastModifiedTime: mustParseTime("2019-05-25T22:00:00.000Z"), Markdown: "Read a pamphlet from The Cat Society"},
+		types.JournalEntry{Date: "2019-05-24", LastModifiedTime: mustParseTime("2019-05-25T06:00:00.000Z"), Markdown: "Read the news today... Oh boy!"},
+		types.JournalEntry{Date: "2019-05-17", LastModifiedTime: mustParseTime("2019-05-16T00:00:00.000Z"), Markdown: "Took a nap and dreamed about chocolate"},
 	}
 	ds := mockDatastore{
 		journalEntries: entries,
@@ -74,10 +74,10 @@ func TestRecentEntriesHandlerSortsByDateThenByModifedTimeInDescendingOrder(t *te
 
 func TestRecentEntriesHandlerAlwaysPlacesNewDatesAheadOfOldDates(t *testing.T) {
 	entries := []types.JournalEntry{
-		types.JournalEntry{Date: "2019-05-17", LastModified: "2019-09-28T12:00:00.000Z", Markdown: "Made a hat out of donuts from the cloud in the sky"},
-		types.JournalEntry{Date: "2019-09-20", LastModified: "2019-09-25T00:00:00.000Z", Markdown: "High fived a platypus when the apple hits the pie."},
-		types.JournalEntry{Date: "2019-09-06", LastModified: "2019-09-22T00:00:00.000Z", Markdown: "Ate an apple in a single bite of choclate"},
-		types.JournalEntry{Date: "2019-09-20", LastModified: "2019-09-20T00:00:00.000Z", Markdown: "Attended an Indie Hackers meetup"},
+		types.JournalEntry{Date: "2019-05-17", LastModifiedTime: "2019-09-28T12:00:00.000Z", Markdown: "Made a hat out of donuts from the cloud in the sky"},
+		types.JournalEntry{Date: "2019-09-20", LastModifiedTime: "2019-09-25T00:00:00.000Z", Markdown: "High fived a platypus when the apple hits the pie."},
+		types.JournalEntry{Date: "2019-09-06", LastModifiedTime: "2019-09-22T00:00:00.000Z", Markdown: "Ate an apple in a single bite of choclate"},
+		types.JournalEntry{Date: "2019-09-20", LastModifiedTime: "2019-09-20T00:00:00.000Z", Markdown: "Attended an Indie Hackers meetup"},
 	}
 	ds := mockDatastore{
 		journalEntries: entries,
@@ -127,12 +127,12 @@ func TestRecentEntriesHandlerAlwaysPlacesNewDatesAheadOfOldDates(t *testing.T) {
 
 func TestRecentEntriesObservesStartAndLimitParameters(t *testing.T) {
 	entries := []types.JournalEntry{
-		types.JournalEntry{Date: "2019-05-10", LastModified: "2019-05-25T06:00:00.000Z", Markdown: "Read the news today... Oh boy!"},
-		types.JournalEntry{Date: "2019-05-03", LastModified: "2019-05-16T00:00:00.000Z", Markdown: "Took a nap and dreamed about chocolate"},
-		types.JournalEntry{Date: "2019-04-26", LastModified: "2019-05-25T00:00:00.000Z", Markdown: "Read a book about the history of cheese"},
-		types.JournalEntry{Date: "2019-04-19", LastModified: "2019-05-17T12:00:00.000Z", Markdown: "Saw a movie about French vanilla"},
-		types.JournalEntry{Date: "2019-04-12", LastModified: "2019-05-23T00:00:00.000Z", Markdown: "Ate some crackers in a bathtub"},
-		types.JournalEntry{Date: "2019-04-05", LastModified: "2019-05-24T00:00:00.000Z", Markdown: "Rode the bus and saw a movie about ghosts"},
+		types.JournalEntry{Date: "2019-05-10", LastModifiedTime: "2019-05-25T06:00:00.000Z", Markdown: "Read the news today... Oh boy!"},
+		types.JournalEntry{Date: "2019-05-03", LastModifiedTime: "2019-05-16T00:00:00.000Z", Markdown: "Took a nap and dreamed about chocolate"},
+		types.JournalEntry{Date: "2019-04-26", LastModifiedTime: "2019-05-25T00:00:00.000Z", Markdown: "Read a book about the history of cheese"},
+		types.JournalEntry{Date: "2019-04-19", LastModifiedTime: "2019-05-17T12:00:00.000Z", Markdown: "Saw a movie about French vanilla"},
+		types.JournalEntry{Date: "2019-04-12", LastModifiedTime: "2019-05-23T00:00:00.000Z", Markdown: "Ate some crackers in a bathtub"},
+		types.JournalEntry{Date: "2019-04-05", LastModifiedTime: "2019-05-24T00:00:00.000Z", Markdown: "Rode the bus and saw a movie about ghosts"},
 	}
 	ds := mockDatastore{
 		journalEntries: entries,

--- a/backend/types/journal_entry.go
+++ b/backend/types/journal_entry.go
@@ -1,9 +1,12 @@
 package types
 
+import "time"
+
 // JournalEntry represents a user's What Got Done update. The entry can be
 // public or a private draft that has not yet been published.
 type JournalEntry struct {
-	Date         string `json:"date" yaml:"date" firestore:"date,omitempty"`
-	LastModified string `json:"lastModified" yaml:"lastModified" firestore:"lastModified,omitempty"`
-	Markdown     string `json:"markdown" yaml:"markdown" firestore:"markdown,omitempty"`
+	Date             string    `json:"date" yaml:"date" firestore:"date,omitempty"`
+	CreationTime     time.Time `json:"creationTime" yaml:"creationTime" firestore:"creationTime"`
+	LastModifiedTime time.Time `json:"lastModifiedTime" yaml:"lastModifiedTime" firestore:"lastModifiedTime"`
+	Markdown         string    `json:"markdown" yaml:"markdown" firestore:"markdown,omitempty"`
 }

--- a/backend/types/reaction.go
+++ b/backend/types/reaction.go
@@ -4,10 +4,7 @@ import "time"
 
 // Reaction to an entity in What Got Done, such as a user liking a journal entry.
 type Reaction struct {
-	Username string `json:"username" firestore:"username,omitempty"`
-	Symbol   string `json:"symbol" firestore:"symbol,omitempty"`
-	// Timestamp is deprecated. It is pending deletion once the database is
-	// updated to populate CreationTime in all the stored values.
-	Timestamp    string    `json:"timestamp" firestore:"timestamp,omitempty"`
+	Username     string    `json:"username" firestore:"username,omitempty"`
+	Symbol       string    `json:"symbol" firestore:"symbol,omitempty"`
 	CreationTime time.Time `json:"creationTime" firestore:"timestamp"`
 }

--- a/backend/types/reaction.go
+++ b/backend/types/reaction.go
@@ -1,8 +1,13 @@
 package types
 
+import "time"
+
 // Reaction to an entity in What Got Done, such as a user liking a journal entry.
 type Reaction struct {
-	Username  string `json:"username" firestore:"username,omitempty"`
-	Symbol    string `json:"symbol" firestore:"symbol,omitempty"`
-	Timestamp string `json:"timestamp" firestore:"timestamp,omitempty"`
+	Username string `json:"username" firestore:"username,omitempty"`
+	Symbol   string `json:"symbol" firestore:"symbol,omitempty"`
+	// Timestamp is deprecated. It is pending deletion once the database is
+	// updated to populate CreationTime in all the stored values.
+	Timestamp    string    `json:"timestamp" firestore:"timestamp,omitempty"`
+	CreationTime time.Time `json:"creationTime" firestore:"timestamp"`
 }


### PR DESCRIPTION
I chose to use the string representation before I realized that Go's firestore library can transparently serialize/deserialize time.Time objects to and from Firestore.