### PR TITLE
Check if authentication is required after checking login state

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -28,11 +28,29 @@ export default {
         updateLoginState();
       } else {
         this.$store.commit('clearLoginState');
+        if (this.routeRequiresLogin) {
+          this.$router.push('/login');
+        }
       }
     });
     getRecent(/*start=*/ 0).then(recentEntries => {
       this.$store.commit('setRecent', recentEntries);
     });
+  },
+  computed: {
+    routeRequiresLogin: function() {
+      const routeName = this.$router.currentRoute.name;
+      if (!routeName) {
+        return false;
+      }
+      if (routeName === 'Preferences') {
+        return true;
+      }
+      if (routeName.indexOf('Edit') === 0) {
+        return true;
+      }
+      return false;
+    },
   },
 };
 </script>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -21,10 +21,10 @@ const routes = [
   {path: '/about', component: Home},
   {path: '/feed', component: PersonalizedFeed},
   {path: '/recent', component: Recent},
-  {path: '/entry/edit/:date', component: EditEntry},
+  {path: '/entry/edit/:date', component: EditEntry, name: 'EditEntry'},
   {path: '/login', component: Login},
   {path: '/logout', component: Logout},
-  {path: '/preferences', component: UserPreferences},
+  {path: '/preferences', component: UserPreferences, name: 'Preferences'},
   {path: '/privacy-policy', component: PrivacyPolicy},
   {
     path: '/:username',
@@ -35,7 +35,7 @@ const routes = [
       },
     },
   },
-  {path: '/profile/edit', component: EditUserProfile},
+  {path: '/profile/edit', component: EditUserProfile, name: 'EditProfile'},
   {
     path: '/:username/:date',
     component: ViewEntry,

--- a/integration/cypress/integration/login_spec.js
+++ b/integration/cypress/integration/login_spec.js
@@ -78,3 +78,26 @@ it("bare route should redirect authenticated user to their edit entry page", () 
   cy.get(".navbar .navbar-brand").click();
   cy.location("pathname").should("eq", "/");
 });
+
+it("visiting authenticated page after UserKit token expires should redirect to login", () => {
+  cy.visit("/");
+  cy.get(".post-update").click();
+  cy.completeLoginForm("joe123");
+
+  cy.location("pathname").should("contain", "/entry/edit");
+  cy.get(".account-dropdown").click();
+  cy.get(".preferences-link a").click();
+
+  cy.location("pathname").should("eq", "/preferences");
+
+  // Simulate a UserKit cookie going stale.
+  cy.setCookie("userkit_auth_token", "");
+
+  cy.reload();
+
+  cy.location("pathname").should("eq", "/login");
+  cy.completeLoginForm("joe123");
+
+  // Redirect to where the user was before the redirect.
+  cy.location("pathname").should("eq", "/preferences");
+});


### PR DESCRIPTION
If the What Got Done's store thinks the user is logged in, but UserKit says they're not, they'll end up in a weird state where they stay on a page they're not authenticated to interact with. This adds a check after the UserKit authentication to redirect the user to login if they need authentication on the given page.