### PR TITLE
Task list shouldn't show bullet points next to check box #434

### DIFF
--- a/frontend/src/components/Journal.vue
+++ b/frontend/src/components/Journal.vue
@@ -45,6 +45,10 @@ export default {
   overflow: auto;
 }
 
+.journal-body >>> .contains-task-list {
+  list-style-type: none;
+}
+
 @media screen and (min-width: 768px) {
   overflow: visible;
 }

--- a/frontend/src/components/JournalPreview.vue
+++ b/frontend/src/components/JournalPreview.vue
@@ -51,4 +51,8 @@ export default {
 .content {
   padding: 4px 14px;
 }
+
+.content >>> .contains-task-list {
+  list-style-type: none;
+}
 </style>

--- a/frontend/src/components/PartialJournal.vue
+++ b/frontend/src/components/PartialJournal.vue
@@ -85,4 +85,8 @@ div.journal {
   text-align: left;
   margin-bottom: 50px;
 }
+
+.journal-body >>> .contains-task-list {
+  list-style-type: none;
+}
 </style>


### PR DESCRIPTION
Added scoped css to display no bullets for task lists.

Fixes #434 

---
*Tip*: If you add the above "Fixes ..." line to your PR description, it automatically closes the bug when the PR is merged.