### PR TITLE
Fix flakiness in login_spec

### DIFF
--- a/integration/cypress/integration/login_spec.js
+++ b/integration/cypress/integration/login_spec.js
@@ -64,6 +64,7 @@ it("bare route should redirect authenticated user to their edit entry page", () 
   cy.location("pathname").should("contain", "/entry/edit/");
 
   // Clicking navbar brand should point to edit entry page.
+  cy.visit("/");
   cy.get(".navbar .navbar-brand").click();
   cy.location("pathname").should("contain", "/entry/edit/");
 


### PR DESCRIPTION
We never left the /entry/edit route, so we're likely running through the test too quickly and confusing login state.