### PR TITLE
Remove Ok field from backend responses

### DIFF
--- a/backend/handlers/draft.go
+++ b/backend/handlers/draft.go
@@ -90,12 +90,6 @@ func (s defaultServer) draftPost() http.HandlerFunc {
 			http.Error(w, "Failed to update draft entry", http.StatusInternalServerError)
 			return
 		}
-		resp := draftResponse{
-			Ok: true,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
 	}
 }
 

--- a/backend/handlers/entries.go
+++ b/backend/handlers/entries.go
@@ -84,11 +84,9 @@ func (s *defaultServer) entryPost() http.HandlerFunc {
 		}
 
 		type entryResponse struct {
-			Ok   bool   `json:"ok"`
 			Path string `json:"path"`
 		}
 		resp := entryResponse{
-			Ok:   true,
 			Path: fmt.Sprintf("/%s/%s", username, date),
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/backend/handlers/follow.go
+++ b/backend/handlers/follow.go
@@ -50,16 +50,6 @@ func (s defaultServer) followPut() http.HandlerFunc {
 			http.Error(w, "Failed to follow user", http.StatusInternalServerError)
 			return
 		}
-
-		type response struct {
-			Ok bool `json:"ok"`
-		}
-		resp := response{
-			Ok: true,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
 	}
 }
 
@@ -84,16 +74,6 @@ func (s defaultServer) followDelete() http.HandlerFunc {
 			http.Error(w, "Failed to unfollow user", http.StatusInternalServerError)
 			return
 		}
-
-		type response struct {
-			Ok bool `json:"ok"`
-		}
-		resp := response{
-			Ok: true,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
 	}
 }
 
@@ -114,11 +94,9 @@ func (s defaultServer) userFollowingGet() http.HandlerFunc {
 		}
 
 		type response struct {
-			Ok        bool     `json:"ok"`
 			Following []string `json:"following"`
 		}
 		resp := response{
-			Ok:        true,
 			Following: leaders,
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/backend/handlers/preferences.go
+++ b/backend/handlers/preferences.go
@@ -59,16 +59,6 @@ func (s defaultServer) preferencesPost() http.HandlerFunc {
 			http.Error(w, "Failed to save preferences", http.StatusInternalServerError)
 			return
 		}
-
-		type response struct {
-			Ok bool `json:"ok"`
-		}
-		resp := response{
-			Ok: true,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
 	}
 }
 

--- a/backend/handlers/reactions.go
+++ b/backend/handlers/reactions.go
@@ -93,16 +93,6 @@ func (s defaultServer) reactionsPost() http.HandlerFunc {
 			http.Error(w, "Failed to add reaction", http.StatusInternalServerError)
 			return
 		}
-
-		type reactionResponse struct {
-			Ok bool `json:"ok"`
-		}
-		resp := reactionResponse{
-			Ok: true,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
 	}
 }
 

--- a/backend/handlers/user.go
+++ b/backend/handlers/user.go
@@ -84,16 +84,6 @@ func (s defaultServer) userPost() http.HandlerFunc {
 			http.Error(w, "Failed to update user profile", http.StatusInternalServerError)
 			return
 		}
-
-		type profileUpdateResponse struct {
-			Ok bool `json:"ok"`
-		}
-		resp := profileUpdateResponse{
-			Ok: true,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
 	}
 }
 

--- a/test-data-manager/server.go
+++ b/test-data-manager/server.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -30,15 +29,6 @@ func (s *server) resetPost() http.HandlerFunc {
 			log.Printf("failed to reset datstore: %v", err)
 			http.Error(w, fmt.Sprintf("Failed to reset datastore: %v", err), http.StatusInternalServerError)
 			return
-		}
-		type response struct {
-			Ok bool `json:"ok"`
-		}
-		resp := response{
-			Ok: true,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
 		}
 	}
 }


### PR DESCRIPTION
The frontend never actually checks it, so it's unnecessary. In cases where it's the only part of the response, it's fine to just return an HTTP 200 OK with an empty body.