### PR TITLE
Fix save button on edit screen so it doesn't collide with hr

### DIFF
--- a/frontend/src/views/EditUserProfile.vue
+++ b/frontend/src/views/EditUserProfile.vue
@@ -45,7 +45,7 @@
 
     <b-button
       variant="primary"
-      class="float-right"
+      class="d-block ml-auto"
       @click.prevent="handleSave()"
       id="save-profile"
       >Save</b-button


### PR DESCRIPTION
Switch to ml-auto instead of float-right, as float-right was causing it to sit on top of the horizontal rule element following it.