### PR TITLE
Narrow CSS rule for text color

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -65,8 +65,8 @@ export default {
   margin-top: 60px;
 }
 
-/* TODO: Remove the #app part of the selector */
-#app a {
+body p a,
+body .alert a {
   color: rgb(101, 168, 255);
 }
 


### PR DESCRIPTION
Previous rule was too broad and included non-text links.