### PR TITLE
Add support for Cache-Control in gcs.UploadFile

### DIFF
--- a/backend/gcs/upload.go
+++ b/backend/gcs/upload.go
@@ -10,7 +10,11 @@ import (
 	"cloud.google.com/go/storage"
 )
 
-func (c Client) UploadFile(r io.Reader, path, contentType string) (string, error) {
+// CacheControlPublic indicates that any cache can store the response.
+const CacheControlPublic = "public"
+
+// UploadFile uploads a file to a lcoation on Google Cloud Storage.
+func (c Client) UploadFile(r io.Reader, path, contentType, cacheControl string) (string, error) {
 	log.Printf("Saving image to gs://%s/%s", c.bucketName, path)
 	ctx := context.Background()
 	bh := c.gcsClient.Bucket(c.bucketName)
@@ -27,7 +31,8 @@ func (c Client) UploadFile(r io.Reader, path, contentType string) (string, error
 	}
 
 	_, err := obj.Update(ctx, storage.ObjectAttrsToUpdate{
-		ContentType: contentType,
+		ContentType:  contentType,
+		CacheControl: cacheControl,
 	})
 	if err != nil {
 		return "", err

--- a/backend/handlers/media.go
+++ b/backend/handlers/media.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"github.com/mtlynch/whatgotdone/backend/dates"
+	"github.com/mtlynch/whatgotdone/backend/gcs"
 )
 
 func (s *defaultServer) mediaPut() http.HandlerFunc {
@@ -40,7 +41,7 @@ func (s *defaultServer) mediaPut() http.HandlerFunc {
 			return
 		}
 
-		url, err := s.gcsClient.UploadFile(mediaFile, path, contentType)
+		url, err := s.gcsClient.UploadFile(mediaFile, path, contentType, gcs.CacheControlPublic)
 		if err != nil {
 			log.Printf("failed to read media from request: %v", err)
 			http.Error(w, fmt.Sprintf("Media upload failed: %v", err), http.StatusBadRequest)


### PR DESCRIPTION
We need this in a future PR to support cache control policies other than 'public', which is GCS's default.