### PR TITLE
Switch media to media.whatgotdone.com bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
             echo "env_variables:" > env_variables.yaml && \
             echo "  CSRF_SECRET_SEED: '${CSRF_SECRET_SEED}'" >> env_variables.yaml && \
             echo "  USERKIT_SECRET: '${USERKIT_SECRET_PROD}'" >> env_variables.yaml && \
-            echo "  PUBLIC_GCS_BUCKET: '${PUBLIC_GCS_BUCKET}'" >> env_variables.yaml && \
+            echo "  PUBLIC_GCS_BUCKET: 'media.whatgotdone.com'" >> env_variables.yaml && \
             echo "  GOOGLE_ANALYTICS_VIEW_ID: '${GOOGLE_ANALYTICS_VIEW_ID}'" >> env_variables.yaml
       - run:
           name: Retrieve Google Analytics service account client secret from CircleCI

--- a/backend/handlers/csp_common.go
+++ b/backend/handlers/csp_common.go
@@ -37,9 +37,10 @@ func contentSecurityPolicy() string {
 		},
 		"img-src": {
 			"'self'",
-			"https://storage.googleapis.com/whatgotdone-public/",
 			// For bootstrap navbar images
 			"data:",
+			// For user-generated uploads
+			"https://media.whatgotdone.com",
 			// For Google Analytics
 			"https://www.google-analytics.com",
 			// For Google Sign In


### PR DESCRIPTION
Waiting for GCS to update certificates for:

https://media.whatgotdone.com/avatars/michael/michael-avatar-300px.jpg

Then:

```bash
cd $(mktemp -d) && \
  gsutil -m cp -r \
    "gs://whatgotdone-public/avatars/" \
    "gs://whatgotdone-public/uploads/" \
     . && \
  gsutil -m cp -r uploads gs://media.whatgotdone.com/ && \
  gsutil -m cp -r avatars  gs://media.whatgotdone.com/
```
