### PR TITLE
Downgrade bootswatch back to 4.6.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5244,9 +5244,9 @@
       }
     },
     "bootswatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-5.0.1.tgz",
-      "integrity": "sha512-qTTUvlBzyd7VR8S089uYRmCYmrAZruPhqEE9yCdek0fm4ELbJ3hGKAILT/tEv3N3r5Aps4teybQr/uCG3e9IaA=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-4.6.0.tgz",
+      "integrity": "sha512-Yr6YqFBC8jwTzoJoLViYlvO97IhPWGqZEm+6FXHfD/G6gbUok6sZkdXxdh4Zb6iCGEwr9p7zGCn38yKQD/bh2Q=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.21.1",
     "babel-runtime": "^6.26.0",
     "bootstrap-vue": "^2.21.2",
-    "bootswatch": "^5.0.1",
+    "bootswatch": "^4.6.0",
     "core-js": "^3.14.0",
     "lodash": "^4.17.21",
     "showdown": "^1.9.1",


### PR DESCRIPTION
Bootswatch 5.0.0 depends on bootstrap 5, which What Got Done is not yet ready for