### PR TITLE
Adjust containers in frontend

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <NavigationBar />
-    <div id="app" class="container">
+    <b-container id="app">
       <router-view></router-view>
-    </div>
+    </b-container>
     <Footer />
   </div>
 </template>

--- a/frontend/src/views/ViewEntry.vue
+++ b/frontend/src/views/ViewEntry.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="view-entry container">
+  <div class="view-entry">
     <template v-if="journalEntries.length > 0">
       <b-pagination-nav
         :pages="pages"


### PR DESCRIPTION
The view entry page doesn't need an extra container, and we can use b-container to take advantage of bootstrap-vue features.