### PR TITLE
Add empty Cypress plugins file

### DIFF
--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -1,5 +1,4 @@
 {
-  "pluginsFile": false,
   "defaultCommandTimeout": 10000,
   "videoCompression": false
 }

--- a/integration/cypress/plugins/index.js
+++ b/integration/cypress/plugins/index.js
@@ -1,0 +1,3 @@
+module.exports = function (on, config) {
+  // Add plugins here.
+};


### PR DESCRIPTION
It's too much of a gotcha that the cypress.json file ignores it in case we ever add one during testing/debugging.