### PR TITLE
Refactor JSON handlers to use common response method

### DIFF
--- a/backend/handlers/draft.go
+++ b/backend/handlers/draft.go
@@ -36,15 +36,11 @@ func (s defaultServer) draftGet() http.HandlerFunc {
 			return
 		}
 
-		type response struct {
+		respondOK(w, struct {
 			Markdown string `json:"markdown"`
-		}
-		resp := response{
+		}{
 			Markdown: draftMarkdown,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
+		})
 	}
 }
 

--- a/backend/handlers/entries.go
+++ b/backend/handlers/entries.go
@@ -25,10 +25,7 @@ func (s *defaultServer) entriesGet() http.HandlerFunc {
 			http.Error(w, fmt.Sprintf("Failed to retrieve entries for %s", username), http.StatusInternalServerError)
 			return
 		}
-
-		if err := json.NewEncoder(w).Encode(entries); err != nil {
-			panic(err)
-		}
+		respondOK(w, entries)
 	}
 }
 
@@ -83,14 +80,10 @@ func (s *defaultServer) entryPost() http.HandlerFunc {
 			return
 		}
 
-		type entryResponse struct {
+		respondOK(w, struct {
 			Path string `json:"path"`
-		}
-		resp := entryResponse{
+		}{
 			Path: fmt.Sprintf("/%s/%s", username, date),
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
+		})
 	}
 }

--- a/backend/handlers/follow.go
+++ b/backend/handlers/follow.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -94,14 +93,10 @@ func (s defaultServer) userFollowingGet() http.HandlerFunc {
 			return
 		}
 
-		type response struct {
+		respondOK(w, struct {
 			Following []types.Username `json:"following"`
-		}
-		resp := response{
+		}{
 			Following: leaders,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
+		})
 	}
 }

--- a/backend/handlers/google_analytics.go
+++ b/backend/handlers/google_analytics.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -64,9 +63,7 @@ func (s defaultServer) pageViewsGet() http.HandlerFunc {
 			Views: views,
 		}
 
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			panic(err)
-		}
+		respondOK(w, response)
 	}
 }
 
@@ -116,9 +113,7 @@ func (s *defaultServer) refreshGoogleAnalytics() http.HandlerFunc {
 			}(pvc)
 		}
 		wg.Wait()
-		if err := json.NewEncoder(w).Encode(true); err != nil {
-			panic(err)
-		}
+		respondOK(w, true)
 	}
 }
 

--- a/backend/handlers/media.go
+++ b/backend/handlers/media.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -49,15 +48,11 @@ func (s *defaultServer) mediaPut() http.HandlerFunc {
 			return
 		}
 
-		type response struct {
+		respondOK(w, struct {
 			URL string `json:"url"`
-		}
-		resp := response{
+		}{
 			URL: url,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
+		})
 	}
 }
 

--- a/backend/handlers/preferences.go
+++ b/backend/handlers/preferences.go
@@ -28,15 +28,11 @@ func (s defaultServer) preferencesGet() http.HandlerFunc {
 			return
 		}
 
-		type response struct {
+		respondOK(w, struct {
 			EntryTemplate string `json:"entryTemplate"`
-		}
-		resp := response{
+		}{
 			EntryTemplate: prefs.EntryTemplate,
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
+		})
 	}
 }
 

--- a/backend/handlers/project.go
+++ b/backend/handlers/project.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -55,8 +54,6 @@ func (s *defaultServer) projectGet() http.HandlerFunc {
 			})
 		}
 
-		if err := json.NewEncoder(w).Encode(projectBodies); err != nil {
-			panic(err)
-		}
+		respondOK(w, projectBodies)
 	}
 }

--- a/backend/handlers/reactions.go
+++ b/backend/handlers/reactions.go
@@ -41,9 +41,7 @@ func (s defaultServer) reactionsGet() http.HandlerFunc {
 			}
 		}
 
-		if err := json.NewEncoder(w).Encode(reactionsFiltered); err != nil {
-			panic(err)
-		}
+		respondOK(w, reactionsFiltered)
 	}
 }
 

--- a/backend/handlers/recent_entries.go
+++ b/backend/handlers/recent_entries.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -39,9 +38,7 @@ func (s *defaultServer) recentEntriesGet() http.HandlerFunc {
 			return
 		}
 
-		if err := json.NewEncoder(w).Encode(recentEntriesToPublicEntries(entries)); err != nil {
-			panic(err)
-		}
+		respondOK(w, recentEntriesToPublicEntries(entries))
 	}
 }
 
@@ -70,15 +67,11 @@ func (s *defaultServer) entriesFollowingGet() http.HandlerFunc {
 			return
 		}
 
-		type response struct {
+		respondOK(w, struct {
 			Entries entriesPublic `json:"entries"`
-		}
-		resp := response{
+		}{
 			Entries: recentEntriesToPublicEntries(entries),
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
+		})
 	}
 }
 

--- a/backend/handlers/respond.go
+++ b/backend/handlers/respond.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func encodeBody(w http.ResponseWriter, v interface{}) error {
+	return json.NewEncoder(w).Encode(v)
+}
+
+func respond(w http.ResponseWriter, status int, data interface{}) {
+	w.WriteHeader(status)
+	if data != nil {
+		encodeBody(w, data)
+	}
+}
+
+func respondOK(w http.ResponseWriter, data interface{}) {
+	respond(w, http.StatusOK, data)
+}

--- a/backend/handlers/user.go
+++ b/backend/handlers/user.go
@@ -30,23 +30,17 @@ func (s defaultServer) userGet() http.HandlerFunc {
 			return
 		}
 
-		type userResponse struct {
+		respondOK(w, struct {
 			AboutMarkdown   string `json:"aboutMarkdown"`
 			TwitterHandle   string `json:"twitterHandle"`
 			EmailAddress    string `json:"emailAddress"`
 			MastodonAddress string `json:"mastodonAddress"`
-		}
-
-		resp := userResponse{
+		}{
 			AboutMarkdown:   string(p.AboutMarkdown),
 			TwitterHandle:   string(p.TwitterHandle),
 			EmailAddress:    string(p.EmailAddress),
 			MastodonAddress: string(p.MastodonAddress),
-		}
-
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
+		})
 	}
 }
 
@@ -82,16 +76,11 @@ func (s defaultServer) userMeGet() http.HandlerFunc {
 			return
 		}
 
-		type userMeResponse struct {
+		respondOK(w, struct {
 			Username types.Username `json:"username"`
-		}
-		resp := userMeResponse{
+		}{
 			Username: username,
-		}
-
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			panic(err)
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
Refactor all the HTTP handlers that return JSON data to use a common handler function, respondOK, which abstracts away the details of the encoding.

Also, switches to anonymous structs for data types that are only used once.