### PR TITLE
Add comment to entries handler

### DIFF
--- a/backend/handlers/entries.go
+++ b/backend/handlers/entries.go
@@ -67,12 +67,14 @@ func (s *defaultServer) entryPost() http.HandlerFunc {
 			Markdown:     t.EntryContent,
 		}
 
+		// First update the latest draft entry.
 		err = s.datastore.InsertDraft(username, j)
 		if err != nil {
 			log.Printf("Failed to update journal draft entry: %s", err)
 			http.Error(w, "Failed to insert entry", http.StatusInternalServerError)
 			return
 		}
+		// Then, update the published version.
 		err = s.datastore.InsertEntry(username, j)
 		if err != nil {
 			log.Printf("Failed to insert journal entry: %s", err)


### PR DESCRIPTION
Remind the reader that publishing the entry also updates the associated draft for that entry.