### PR TITLE
Change the behavior of datastore.Users to include more users

### DIFF
--- a/backend/datastore/datastore.go
+++ b/backend/datastore/datastore.go
@@ -14,7 +14,8 @@ import (
 // storing and retrieving all persistent data (journal entries, journal drafts,
 // reactions).
 type Datastore interface {
-	// Users returns all the users who have published entries.
+	// Users returns all the users who have saved drafts, profiles, or
+	// preferences.
 	Users() ([]types.Username, error)
 	// GetUserProfile returns profile information for the given user.
 	GetUserProfile(username types.Username) (types.UserProfile, error)

--- a/backend/handlers/user.go
+++ b/backend/handlers/user.go
@@ -96,9 +96,9 @@ func profileFromRequest(r *http.Request) (types.UserProfile, error) {
 }
 
 func (s defaultServer) userExists(username types.Username) (bool, error) {
-	// BUG: Will only detect users who have published an entry. Ideally, we'd be
-	// able to tell if the username exists in UserKit, but the UserKit API
-	// currently does not offer lookup by username.
+	// BUG: Will only detect users who have saved information into What Got Done.
+	// Ideally, we'd be able to tell if the username exists in UserKit, but the
+	// UserKit API currently does not offer lookup by username.
 	users, err := s.datastore.Users()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Previously, it was limited to users who have published entries. This expands the function to include users who have saved preferences, saved a draft entry, or saved profile information.

Notably, this leaves out users who haven't interacted with What Got Done or whose only interaction is following other users or reacting to posts.