### PR TITLE
Fix firestore query for usernames

### DIFF
--- a/backend/datastore/firestore/user.go
+++ b/backend/datastore/firestore/user.go
@@ -49,9 +49,7 @@ func (c client) usernamesInCollection(collectionKey string) ([]types.Username, e
 		if err != nil {
 			return nil, err
 		}
-		var u userDocument
-		doc.DataTo(&u)
-		users = append(users, u.Username)
+		users = append(users, types.Username(doc.Ref.ID))
 	}
 	return users, nil
 }


### PR DESCRIPTION
Retrieve the keys of the collection rather than trying to parse the document.