### PR TITLE
Remove tiptap test workaround

### DIFF
--- a/integration/cypress/integration/rich_text_editor_spec.js
+++ b/integration/cypress/integration/rich_text_editor_spec.js
@@ -1,9 +1,3 @@
-// There seems to be a bug in tiptap where formatting buttons don't apply until
-// the user has typed text.
-function applyTipTapWorkaround() {
-  cy.get(".editor-content .ProseMirror").type("a{backspace}");
-}
-
 it("writes an entry without formatting", () => {
   cy.login("staging_jimmy");
 
@@ -11,7 +5,6 @@ it("writes an entry without formatting", () => {
 
   const entryText = "Posted an update at " + new Date().toISOString();
 
-  applyTipTapWorkaround();
   cy.get(".editor-content .ProseMirror").type(entryText);
   cy.get("form").submit();
 
@@ -25,7 +18,6 @@ it("canonicalizes newlines after bulleted list", () => {
 
   cy.location("pathname").should("include", "/entry/edit");
 
-  applyTipTapWorkaround();
   cy.get(".btn-bulleted-list .btn").click();
   cy.get(".editor-content .ProseMirror").type("a{enter}{enter}b");
 
@@ -39,7 +31,6 @@ it("writes an entry with every type of formatting", () => {
 
   cy.location("pathname").should("include", "/entry/edit");
 
-  applyTipTapWorkaround();
   cy.get(".btn-h1 .btn").click();
   cy.get(".editor-content .ProseMirror").type("Project A{enter}{enter}");
 
@@ -171,7 +162,6 @@ it("supports undo", () => {
 
   cy.location("pathname").should("include", "/entry/edit");
 
-  applyTipTapWorkaround();
   cy.get(".editor-content .ProseMirror").type("Hello, world!");
 
   // Wait for auto-save to complete


### PR DESCRIPTION
As of the latest version, it's no longer necessary.

Fixes #574.