### PR TITLE
Remove content-type header from Media controller

### DIFF
--- a/frontend/src/controllers/Media.js
+++ b/frontend/src/controllers/Media.js
@@ -8,7 +8,6 @@ export function uploadMedia(media) {
     credentials: 'include',
     headers: {
       'X-CSRF-Token': getCsrfToken(),
-      'Content-Type': 'multipart/form-data',
     },
     body: formData,
   }).then(processJsonResponse);


### PR DESCRIPTION
Apparently the browser will set it automatically, and us setting it explicitly messes things up.