### PR TITLE
Update Google Analytics data automatically

### DIFF
--- a/backend/datastore/datastore.go
+++ b/backend/datastore/datastore.go
@@ -6,15 +6,23 @@ package datastore
 
 import (
 	"fmt"
+	"time"
 
 	ga "github.com/mtlynch/whatgotdone/backend/google_analytics"
 	"github.com/mtlynch/whatgotdone/backend/types"
 )
 
-type EntryFilter struct {
-	ByUsers   []types.Username
-	MinLength int32
-}
+type (
+	EntryFilter struct {
+		ByUsers   []types.Username
+		MinLength int32
+	}
+
+	PageViewRecord struct {
+		PageViews   int
+		LastUpdated time.Time
+	}
+)
 
 // Datastore represents the What Got Done datastore. It's responsible for
 // storing and retrieving all persistent data (journal entries, journal drafts,
@@ -46,7 +54,7 @@ type Datastore interface {
 	// InsertPageViews stores the set of pageview data for What Got Done routes.
 	InsertPageViews(pvc []ga.PageViewCount) error
 	// GetPageViews retrieves the count of pageviews for a given What Got Done route.
-	GetPageViews(path string) (int, error)
+	GetPageViews(path string) (PageViewRecord, error)
 	// InsertFollow adds a following relationship to the datastore.
 	InsertFollow(leader, follower types.Username) error
 	// DeleteFollow removes a following relationship from the datastore.

--- a/backend/datastore/mock/mock.go
+++ b/backend/datastore/mock/mock.go
@@ -2,6 +2,8 @@ package mock
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/mtlynch/whatgotdone/backend/datastore"
@@ -12,16 +14,18 @@ import (
 // MockDatastore is a mock implementation of the datstore.Datastore interface
 // for testing.
 type MockDatastore struct {
-	JournalEntries     []types.JournalEntry
-	JournalDrafts      []types.JournalEntry
-	Usernames          []types.Username
-	Reactions          map[types.Username]map[types.EntryDate][]types.Reaction
-	UserFollows        map[types.Username][]types.Username
-	UserPreferences    map[types.Username]types.Preferences
-	PageViewCounts     []ga.PageViewCount
-	LastPageViewUpdate time.Time
-	UserProfile        types.UserProfile
-	ReadEntriesErr     error
+	JournalEntries         []types.JournalEntry
+	JournalDrafts          []types.JournalEntry
+	Usernames              []types.Username
+	Reactions              map[types.Username]map[types.EntryDate][]types.Reaction
+	UserFollows            map[types.Username][]types.Username
+	UserPreferences        map[types.Username]types.Preferences
+	pageViewCounts         []ga.PageViewCount
+	LastPageViewUpdate     time.Time
+	UserProfile            types.UserProfile
+	ReadEntriesErr         error
+	mu                     sync.Mutex
+	CallsToInsertPageViews chan bool
 }
 
 func (ds *MockDatastore) GetUserProfile(username types.Username) (types.UserProfile, error) {
@@ -127,12 +131,24 @@ func (ds *MockDatastore) DeleteReaction(entryAuthor types.Username, entryDate ty
 }
 
 func (ds *MockDatastore) InsertPageViews(pvc []ga.PageViewCount) error {
-	ds.PageViewCounts = pvc
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	defer func() {
+		if ds.CallsToInsertPageViews == nil {
+			return
+		}
+		ds.CallsToInsertPageViews <- true
+	}()
+
+	ds.pageViewCounts = pvc
 	return nil
 }
 
 func (ds *MockDatastore) GetPageViews(path string) (datastore.PageViewRecord, error) {
-	for _, pvc := range ds.PageViewCounts {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	for _, pvc := range ds.pageViewCounts {
 		if pvc.Path == path {
 			return datastore.PageViewRecord{
 				PageViews:   pvc.Views,
@@ -140,7 +156,7 @@ func (ds *MockDatastore) GetPageViews(path string) (datastore.PageViewRecord, er
 			}, nil
 		}
 	}
-	return datastore.PageViewRecord{}, errors.New("no pageview results found")
+	return datastore.PageViewRecord{}, fmt.Errorf("no mock pageview results found for %s", path)
 }
 
 func (ds *MockDatastore) InsertFollow(leader, follower types.Username) error {

--- a/backend/handlers/routes.go
+++ b/backend/handlers/routes.go
@@ -49,7 +49,6 @@ func (s *defaultServer) routes() {
 	api.HandleFunc("/user", s.requireAuthentication(s.userPost())).Methods(http.MethodPost)
 	api.HandleFunc("/logout", allowOptions()).Methods(http.MethodOptions)
 	api.HandleFunc("/logout", s.logoutPost()).Methods(http.MethodPost)
-	api.HandleFunc("/tasks/refreshGoogleAnalytics", s.refreshGoogleAnalytics()).Methods(http.MethodGet)
 
 	// Catchall for when no API route matches.
 	api.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Previously, we relied on an external process to call /api/tasks/refreshGoogleAnalytics periodically. This was a naive approach and required us to refresh analytics and do a lot of datastore writes even when nobody was viewing the site for hours.

This implementation refreshes stats if someone requests pageview stats and it has been more than 3 minutes since the last refresh. Note that it updates it for the next request; the current request will get the stale data, but that's okay, as we assume pageview stats don't change *that* much in a few minutes.