### PR TITLE
Configure gorilla logging to process proxy headers

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	muxHandlers "github.com/gorilla/handlers"
+	gorilla "github.com/gorilla/handlers"
 
 	"github.com/mtlynch/whatgotdone/backend/handlers"
 )
@@ -15,7 +15,7 @@ func main() {
 	log.Print("Starting whatgotdone server")
 
 	s := handlers.New()
-	http.Handle("/", muxHandlers.LoggingHandler(os.Stdout, s.Router()))
+	http.Handle("/", gorilla.ProxyHeaders(gorilla.LoggingHandler(os.Stdout, s.Router())))
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
In production, we run What Got Done behind a proxy, so we should process the proxy headers properly. Otherwise, it looks like all requests are coming from the proxy server.