### PR TITLE
Revert "Configure gorilla logging to process proxy headers (#718)"

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	gorilla "github.com/gorilla/handlers"
+	muxHandlers "github.com/gorilla/handlers"
 
 	"github.com/mtlynch/whatgotdone/backend/handlers"
 )
@@ -15,7 +15,7 @@ func main() {
 	log.Print("Starting whatgotdone server")
 
 	s := handlers.New()
-	http.Handle("/", gorilla.ProxyHeaders(gorilla.LoggingHandler(os.Stdout, s.Router())))
+	http.Handle("/", muxHandlers.LoggingHandler(os.Stdout, s.Router()))
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
This seems to cause PUT and POST requests to fail with `Forbidden - referer invalid`

This reverts commit fbaf256996560639f2e1b06c915d0d50b9600502.