### PR TITLE
Remove filtering logic for empty reactions

### DIFF
--- a/backend/handlers/reactions.go
+++ b/backend/handlers/reactions.go
@@ -33,14 +33,7 @@ func (s defaultServer) reactionsGet() http.HandlerFunc {
 			return
 		}
 
-		reactionsFiltered := []types.Reaction{}
-		for _, reaction := range reactions {
-			if reaction.Symbol != "" {
-				reactionsFiltered = append(reactionsFiltered, reaction)
-			}
-		}
-
-		respondOK(w, reactionsFiltered)
+		respondOK(w, reactions)
 	}
 }
 


### PR DESCRIPTION
As of 1f06a80, the database does not contain empty reactions, so we don't need to filter for them.