### PR TITLE
Add an offset to validation-interval to offset it from snapshot-interval

### DIFF
--- a/litestream.yml
+++ b/litestream.yml
@@ -10,4 +10,6 @@ dbs:
         force-path-style: true
         retention: 720h # 30 days
         snapshot-interval: 24h
-        validation-interval: 12h
+        # The 13m is to prevent snapshot and validations from happening concurrently.
+        # https://github.com/benbjohnson/litestream/issues/253
+        validation-interval: 12h13m


### PR DESCRIPTION
If a snapshot and validation occur at the same time, the validation can incorrectly flag the backups as invalid, so this adds a 13m offset so that they infrequently land on the same time.