### PR TITLE
Make run-go-tests script fast by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           at: ./
       - run:
           name: Test go packages
-          command: dev-scripts/run-go-tests
+          command: dev-scripts/run-go-tests --full
       - store_artifacts:
           path: backend/.coverage.html
       - run:

--- a/dev-scripts/git-hooks/pre-commit
+++ b/dev-scripts/git-hooks/pre-commit
@@ -9,7 +9,7 @@ set -x
 # Exit on unset variable.
 set -u
 
-./dev-scripts/run-go-tests --quick
+./dev-scripts/run-go-tests
 ./dev-scripts/check-go-formatting
 
 pushd backend

--- a/dev-scripts/run-go-tests
+++ b/dev-scripts/run-go-tests
@@ -6,12 +6,12 @@ set -e
 # Echo commands to stdout.
 set -x
 
-if [ "$1" = "--quick" ]; then
-  quick_test=""
-  flags=""
-else
-  quick_test="1"
+if [ "$1" = "--full" ]; then
+  full_test="1"
   flags="-race --coverprofile=.coverage.out"
+else
+  full_test=""
+  flags=""
 fi
 
 # Exit on unset variable.
@@ -33,7 +33,7 @@ go test -v $flags ./...
 go vet ./...
 $STATICCHECK_PATH ./...
 
-if [ ! -z "$quick_test" ]; then
+if [ ! -z "$full_test" ]; then
   go tool cover -html .coverage.out -o .coverage.html
 fi
 popd


### PR DESCRIPTION
Previously, it was slow by default and the user had to pass the --quick flag to make it go fast. Typically, I'll run this script manually during development, so it's easier if the default is fast and we configure CI to run the slower, more comprehensive version.