### PR TITLE
Use the public Router method for testing handlers

### DIFF
--- a/backend/handlers/draft_test.go
+++ b/backend/handlers/draft_test.go
@@ -38,7 +38,7 @@ func TestDraftHandlerWhenUserIsNotLoggedIn(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusForbidden {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -73,7 +73,7 @@ func TestDraftHandlerWhenUserTokenIsInvalid(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_invalid", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusForbidden {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -108,7 +108,7 @@ func TestDraftHandlerWhenDateMatches(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -153,7 +153,7 @@ func TestDraftHandlerReturns404WhenDatastoreReturnsEntryNotFoundError(t *testing
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusNotFound {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -186,7 +186,7 @@ func TestDraftHandlerReturnsBadRequestWhenDateIsInvalid(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusBadRequest {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -227,7 +227,7 @@ func TestPutDraftRejectsEmptyDraft(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	statusExpected := http.StatusBadRequest
 	if status := w.Code; status != statusExpected {
@@ -279,7 +279,7 @@ func TestDeleteDraftDeletesMatchingDraft(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	statusExpected := http.StatusOK
 	if status := w.Code; status != statusExpected {
@@ -337,7 +337,7 @@ func TestDeleteDraftReturnsOKForNonExistentEntry(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	statusExpected := http.StatusOK
 	if status := w.Code; status != statusExpected {
@@ -390,7 +390,7 @@ func TestDeleteDraftReturnsBadRequestForInvalidDate(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	statusExpected := http.StatusBadRequest
 	if status := w.Code; status != statusExpected {

--- a/backend/handlers/entries_test.go
+++ b/backend/handlers/entries_test.go
@@ -52,7 +52,7 @@ func TestEntriesHandler(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -86,7 +86,7 @@ func TestEntriesHandlerWhenUserHasNoEntries(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -123,7 +123,7 @@ func TestEntriesHandlerReturnsBadRequestWhenUsernameIsBlank(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusBadRequest {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -150,7 +150,7 @@ func TestEntriesHandlerReturnsNotFoundWhenUsernameHasNoEntries(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusBadRequest {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -183,7 +183,7 @@ func TestPutEntryRejectsEmptyEntry(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	statusExpected := http.StatusBadRequest
 	if status := w.Code; status != statusExpected {
@@ -235,7 +235,7 @@ func TestDeleteEntryDeletesMatchingEntry(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	statusExpected := http.StatusOK
 	if status := w.Code; status != statusExpected {
@@ -293,7 +293,7 @@ func TestDeleteEntryReturnsOKForNonExistentEntry(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	statusExpected := http.StatusOK
 	if status := w.Code; status != statusExpected {
@@ -346,7 +346,7 @@ func TestDeleteEntryReturnsBadRequestForInvalidDate(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	statusExpected := http.StatusBadRequest
 	if status := w.Code; status != statusExpected {

--- a/backend/handlers/export_test.go
+++ b/backend/handlers/export_test.go
@@ -96,7 +96,7 @@ func TestExportPopulatedUserAccount(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -183,7 +183,7 @@ func TestExportEmptyUserAccount(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_A", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -227,7 +227,7 @@ func TestExportUnauthenticatedAccount(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock-invalid-token", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusForbidden {
 		t.Fatalf("handler returned wrong status code: got %v want %v",

--- a/backend/handlers/google_analytics_test.go
+++ b/backend/handlers/google_analytics_test.go
@@ -88,7 +88,7 @@ func TestPageViewsGet(t *testing.T) {
 		}
 
 		w := httptest.NewRecorder()
-		s.router.ServeHTTP(w, req)
+		s.Router().ServeHTTP(w, req)
 
 		if status := w.Code; status != tt.httpStatusExpected {
 			t.Fatalf("for input [%s], handler returned wrong status code: got %v want %v",
@@ -187,7 +187,7 @@ func TestPageViewsGetUpdatesPageViewsWhenRecordsAreStale(t *testing.T) {
 		t.Fatal(err)
 	}
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusOK)

--- a/backend/handlers/reactions_test.go
+++ b/backend/handlers/reactions_test.go
@@ -39,7 +39,7 @@ func TestReactionsGetWhenEntryHasNoReactions(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -81,7 +81,7 @@ func TestReactionsGetWhenEntryHasTwoReactions(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -120,7 +120,7 @@ func TestReactionsGetWhenEntryAuthorIsUndefined(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusBadRequest {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -153,7 +153,7 @@ func TestReactionsPostStoresValidReaction(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_C", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -200,7 +200,7 @@ func TestReactionsPostRejectsRequestWithMissingSymbolField(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_C", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusBadRequest {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -231,7 +231,7 @@ func TestReactionsRejectsInvalidReactionSymbol(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_C", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusBadRequest {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -262,7 +262,7 @@ func TestReactionsPostRejectsRequestWhenUsernameIsUndefined(t *testing.T) {
 	req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_C", userKitAuthCookieName))
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusBadRequest {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -288,7 +288,7 @@ func TestReactionsPostRejectsRequestWhenUserIsNotLoggedIn(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusForbidden {
 		t.Fatalf("handler returned wrong status code: got %v want %v",

--- a/backend/handlers/recent_entries_test.go
+++ b/backend/handlers/recent_entries_test.go
@@ -69,7 +69,7 @@ func TestRecentEntriesHandlerReturnsRecentEntries(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -156,7 +156,7 @@ func TestRecentEntriesRejectsInvalidStartAndLimitParameters(t *testing.T) {
 		}
 
 		w := httptest.NewRecorder()
-		s.router.ServeHTTP(w, req)
+		s.Router().ServeHTTP(w, req)
 
 		if status := w.Code; status != http.StatusBadRequest {
 			t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -180,7 +180,7 @@ func TestRecentEntriesHandlerReturnsEmptyArrayWhenNoEntriesExist(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusOK {
 		t.Fatalf("handler returned wrong status code: got %v want %v",
@@ -215,7 +215,7 @@ func TestRecentFailsWhenDatastoreFailsToRetrieveEntries(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	s.router.ServeHTTP(w, req)
+	s.Router().ServeHTTP(w, req)
 
 	if status := w.Code; status != http.StatusInternalServerError {
 		t.Fatalf("handler returned wrong status code: got %v want %v",

--- a/backend/handlers/user_test.go
+++ b/backend/handlers/user_test.go
@@ -123,7 +123,7 @@ func TestUserPost(t *testing.T) {
 		req.Header.Set("Cookie", fmt.Sprintf("%s=mock_token_C", userKitAuthCookieName))
 
 		w := httptest.NewRecorder()
-		s.router.ServeHTTP(w, req)
+		s.Router().ServeHTTP(w, req)
 
 		if status := w.Code; status != tt.httpStatusExpected {
 			t.Fatalf("for input [%s], handler returned wrong status code: got %v want %v",


### PR DESCRIPTION
This allows the tests to rely less on internal properties of the server.