### PR TITLE
Switch draft handler tests to use real datastore

### DIFF
--- a/backend/datastore/sqlite/draft.go
+++ b/backend/datastore/sqlite/draft.go
@@ -44,6 +44,7 @@ func (d db) GetDraft(username types.Username, date types.EntryDate) (types.Journ
 	}
 
 	return types.JournalEntry{
+		Author:       username,
 		Date:         date,
 		LastModified: t,
 		Markdown:     types.EntryContent(markdown),


### PR DESCRIPTION
Instead of using a mock datastore, it's better to test with the real SQLite datastore implementation. We use the :memory: path to ensure the DB stays in memory and doesn't persist across tests.