### PR TITLE
Clear cached auth state for any auth error

### DIFF
--- a/frontend/src/controllers/UserState.js
+++ b/frontend/src/controllers/UserState.js
@@ -26,11 +26,7 @@ export default function initializeUserState() {
         resolve();
       })
       .catch((error) => {
-        // If checking user information fails, the cached authentication information
-        // is no longer correct, so we need to clear it.
-        if (error.response && error.response.status === 403) {
-          clearCachedAuthInformation();
-        }
+        clearCachedAuthInformation();
         reject(error);
       });
   });


### PR DESCRIPTION
We weren't doing this check properly, so we should just clear state for any error.