### PR TITLE
Use a test implementation of datastore in tests

### DIFF
--- a/backend/datastore/test_sqlite/db.go
+++ b/backend/datastore/test_sqlite/db.go
@@ -3,9 +3,9 @@ package test_sqlite
 import (
 	"fmt"
 
-	"github.com/mtlynch/whatgotdone/backend/random"
 	"github.com/mtlynch/whatgotdone/backend/datastore"
 	"github.com/mtlynch/whatgotdone/backend/datastore/sqlite"
+	"github.com/mtlynch/whatgotdone/backend/random"
 )
 
 func New() datastore.Datastore {

--- a/backend/datastore/test_sqlite/db.go
+++ b/backend/datastore/test_sqlite/db.go
@@ -1,0 +1,20 @@
+package test_sqlite
+
+import (
+	"fmt"
+
+	"github.com/mtlynch/whatgotdone/backend/random"
+	"github.com/mtlynch/whatgotdone/backend/datastore"
+	"github.com/mtlynch/whatgotdone/backend/datastore/sqlite"
+)
+
+func New() datastore.Datastore {
+	return sqlite.New(ephemeralDbURI())
+}
+
+func ephemeralDbURI() string {
+	name := random.String(
+		10,
+		[]rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"))
+	return fmt.Sprintf("file:%s?mode=memory&cache=shared", name)
+}

--- a/backend/handlers/draft_test.go
+++ b/backend/handlers/draft_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/mtlynch/whatgotdone/backend/datastore"
-	"github.com/mtlynch/whatgotdone/backend/datastore/sqlite"
+	"github.com/mtlynch/whatgotdone/backend/datastore/test_sqlite"
 	"github.com/mtlynch/whatgotdone/backend/types"
 )
 
 func TestDraftHandlerWhenUserIsNotLoggedIn(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	ds.InsertDraft("dummyuser", types.JournalEntry{
 		Date:         "2019-04-19",
 		LastModified: mustParseTime("2019-04-19T00:00:00Z"),
@@ -48,7 +48,7 @@ func TestDraftHandlerWhenUserIsNotLoggedIn(t *testing.T) {
 }
 
 func TestDraftHandlerWhenUserTokenIsInvalid(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	ds.InsertDraft("dummyuser", types.JournalEntry{
 		Date:         "2019-04-19",
 		LastModified: mustParseTime("2019-04-19T00:00:00Z"),
@@ -83,7 +83,7 @@ func TestDraftHandlerWhenUserTokenIsInvalid(t *testing.T) {
 }
 
 func TestDraftHandlerWhenDateMatches(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	ds.InsertDraft("dummyUser", types.JournalEntry{
 		Date:         "2019-04-19",
 		LastModified: mustParseTime("2019-04-19T00:00:00Z"),
@@ -131,7 +131,7 @@ func TestDraftHandlerWhenDateMatches(t *testing.T) {
 }
 
 func TestDraftHandlerReturns404WhenDatastoreReturnsEntryNotFoundError(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	router := mux.NewRouter()
 	s := defaultServer{
 		authenticator: mockAuthenticator{
@@ -161,7 +161,7 @@ func TestDraftHandlerReturns404WhenDatastoreReturnsEntryNotFoundError(t *testing
 }
 
 func TestDraftHandlerReturnsBadRequestWhenDateIsInvalid(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	router := mux.NewRouter()
 	s := defaultServer{
 		authenticator: mockAuthenticator{
@@ -199,7 +199,7 @@ func mustParseTime(ts string) time.Time {
 }
 
 func TestPutDraftRejectsEmptyDraft(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	router := mux.NewRouter()
 	s := defaultServer{
 		authenticator: mockAuthenticator{
@@ -233,7 +233,7 @@ func TestPutDraftRejectsEmptyDraft(t *testing.T) {
 }
 
 func TestDeleteDraftDeletesMatchingDraft(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	ds.InsertDraft("dummyUser", types.JournalEntry{
 		Author:       "dummyUser",
 		Date:         "2019-03-22",
@@ -299,7 +299,7 @@ func TestDeleteDraftDeletesMatchingDraft(t *testing.T) {
 }
 
 func TestDeleteDraftReturnsOKForNonExistentEntry(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	ds.InsertDraft("dummyUser", types.JournalEntry{
 		Author:       "dummyUser",
 		Date:         "2019-03-22",
@@ -342,7 +342,7 @@ func TestDeleteDraftReturnsOKForNonExistentEntry(t *testing.T) {
 }
 
 func TestDeleteDraftReturnsBadRequestForInvalidDate(t *testing.T) {
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	ds.InsertDraft("dummyUser", types.JournalEntry{
 		Author:       "dummyUser",
 		Date:         "2019-03-22",

--- a/backend/handlers/user_test.go
+++ b/backend/handlers/user_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/mtlynch/whatgotdone/backend/datastore/sqlite"
+	"github.com/mtlynch/whatgotdone/backend/datastore/test_sqlite"
 	"github.com/mtlynch/whatgotdone/backend/types"
 )
 
@@ -101,7 +101,7 @@ func TestUserPost(t *testing.T) {
 		},
 	}
 
-	ds := sqlite.New(":memory:")
+	ds := test_sqlite.New()
 	router := mux.NewRouter()
 	s := defaultServer{
 		authenticator: mockAuthenticator{

--- a/backend/random/string.go
+++ b/backend/random/string.go
@@ -1,0 +1,20 @@
+package random
+
+import (
+	"log"
+	"math/rand"
+	"time"
+)
+
+func init() {
+	log.Printf("initializing random seed")
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+func String(n int, characters []rune) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = characters[rand.Intn(len(characters))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
Having multiple tests use :memory: can cause Go to reuse the database across tests. Using a random filename preserves the in-memory behavior without the risk of cross-test contamination.