### PR TITLE
Make GCP creds option for docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: Retrieve staging service account credentials (JSON) from CircleCI
           command: |
             echo "${INTEGRATION_CLIENT_SECRET}" | \
-              base64 --decode > gcp-service-account-staging.json
+              base64 --decode > creds/gcp-service-account-staging.json
       - attach_workspace:
           at: ./
       - run:
@@ -115,7 +115,7 @@ jobs:
           name: Retrieve GCP service account client secret from CircleCI
           command: |
             echo "$GCP_SERVICE_ACCOUNT" | \
-              base64 --decode > gcp-service-account-prod.json
+              base64 --decode > creds/gcp-service-account-prod.json
       - run:
           name: Install flyctl
           command: curl -L https://fly.io/install.sh | sh -s "${FLYCTL_VERSION}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,9 @@ jobs:
       - image: mcr.microsoft.com/playwright:v1.29.2-focal
     steps:
       - checkout
-      - run: Create folder for GCP credentials
-        command: mkdir creds/
+      - run:
+          name: Create folder for GCP credentials
+          command: mkdir creds/
       - run:
           name: Retrieve staging service account credentials (JSON) from CircleCI
           command: |
@@ -113,8 +114,9 @@ jobs:
       FLYCTL_VERSION: "latest"
     steps:
       - checkout
-      - run: Create folder for GCP credentials
-        command: mkdir creds/
+      - run:
+          name: Create folder for GCP credentials
+          command: mkdir creds/
       - run:
           name: Retrieve GCP service account client secret from CircleCI
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ jobs:
       - image: mcr.microsoft.com/playwright:v1.29.2-focal
     steps:
       - checkout
+      - run: Create folder for GCP credentials
+        command: mkdir creds/
       - run:
           name: Retrieve staging service account credentials (JSON) from CircleCI
           command: |
@@ -111,6 +113,8 @@ jobs:
       FLYCTL_VERSION: "latest"
     steps:
       - checkout
+      - run: Create folder for GCP credentials
+        command: mkdir creds/
       - run:
           name: Retrieve GCP service account client secret from CircleCI
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules/
 *.sw?
 
 # GCP service account credentials
-*service-account*.json
+creds
 
 # Holds secret environment variables in prod
 env_variables.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ COPY --from=backend_builder /app/bin/whatgotdone /app/bin/whatgotdone
 COPY --from=litestream_downloader /litestream/litestream /app/litestream
 COPY ./litestream.yml /etc/litestream.yml
 COPY ./docker_entrypoint /app/docker_entrypoint
-COPY ./gcp-service-account-*.json /app/
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ What Got Done supports pulling metrics from Google Analytics into the page conte
 1. Enable the [Google Analytics Reporting API](https://console.cloud.google.com/apis/library/analyticsreporting.googleapis.com) in your Google Cloud Platform project.
 1. Create a [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) in Google Cloud Platform console for your What Got Done project.
    1. Assign the service account no permissions/roles, but save its private key as JSON.
-   1. Click "Create Key" to create a private key and save it in JSON format as `gcp-service-account-prod.json` in the What Got Done root directory.
+   1. Click "Create Key" to create a private key and save it in JSON format as `creds/gcp-service-account-prod.json` in the What Got Done root directory.
 1. In Google Analytics, open Admin > View > View User Management and add the email address of the service account you just created (it will have an email like `[name]@[project ID].iam.gserviceaccount.com`.
    1. Grant the user only "Read & Analyze" permissions.
 1. In Google Analytics, open Admin > View > View Settings

--- a/backend/gcp/service_account_dev.go
+++ b/backend/gcp/service_account_dev.go
@@ -2,4 +2,4 @@
 
 package gcp
 
-const ServiceAccountKeyFile = "gcp-service-account-dev.json"
+const ServiceAccountKeyFile = "creds/gcp-service-account-dev.json"

--- a/backend/gcp/service_account_prod.go
+++ b/backend/gcp/service_account_prod.go
@@ -2,4 +2,4 @@
 
 package gcp
 
-const ServiceAccountKeyFile = "gcp-service-account-prod.json"
+const ServiceAccountKeyFile = "creds/gcp-service-account-prod.json"

--- a/backend/gcp/service_account_staging.go
+++ b/backend/gcp/service_account_staging.go
@@ -2,4 +2,4 @@
 
 package gcp
 
-const ServiceAccountKeyFile = "gcp-service-account-staging.json"
+const ServiceAccountKeyFile = "creds/gcp-service-account-staging.json"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,5 @@ services:
       - PORT=3001
       - CSRF_SECRET_SEED=dummy-dev-secret-seed
       - USERKIT_SECRET=dummy.dummy
+    volumes:
+      - ./creds:/app/creds


### PR DESCRIPTION
docker-compose unintentionally had a dependency on the existence of GCP service account secrets, which are actually optional. This fixes docker-compose so that it can run even if GCP service account credentials are not present on the filesystem.