### PR TITLE
Build credentials folder into Docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Create folder for GCP credentials
-          command: mkdir creds/
-      - run:
           name: Retrieve staging service account credentials (JSON) from CircleCI
           command: |
             echo "${INTEGRATION_CLIENT_SECRET}" | \
@@ -114,9 +111,6 @@ jobs:
       FLYCTL_VERSION: "latest"
     steps:
       - checkout
-      - run:
-          name: Create folder for GCP credentials
-          command: mkdir creds/
       - run:
           name: Retrieve GCP service account client secret from CircleCI
           command: |

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ bin
 frontend/dist
 frontend/node_modules
 data/
+creds/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ node_modules/
 *.sw?
 
 # GCP service account credentials
-creds
+creds/*
+!creds/README.md
 
 # Holds secret environment variables in prod
 env_variables.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN apk add --no-cache bash
 COPY --from=frontend_builder /app/frontend/dist /app/frontend/dist
 COPY --from=backend_builder /app/bin/whatgotdone /app/bin/whatgotdone
 COPY --from=litestream_downloader /litestream/litestream /app/litestream
+COPY ./creds /app/creds
 COPY ./litestream.yml /etc/litestream.yml
 COPY ./docker_entrypoint /app/docker_entrypoint
 

--- a/creds/README.md
+++ b/creds/README.md
@@ -1,0 +1,9 @@
+# creds
+
+This folder contains GCP service account tokens. For development and production, these tokens are optional:
+
+* `gcp-service-account-dev.json`: For development
+* `gcp-service-account-staging.json`: For end-to-end tests
+* `gcp-service-account-prod.json`: For production
+
+See `dev-scripts/generate-gcloud-auth-token` for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,3 @@ services:
       - PORT=3001
       - CSRF_SECRET_SEED=dummy-dev-secret-seed
       - USERKIT_SECRET=dummy.dummy
-    volumes:
-      - ./creds:/app/creds


### PR DESCRIPTION
Fixes a regression caused by 0c8400db762a2efae0286a15bbddbb37c2cc7124 that prevented production builds from keeping GCP creds and using GCS buckets.