### PR TITLE
Don't upload e2e-results to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,6 @@ jobs:
           command: ./dev-scripts/run-e2e-tests --skip-rebuild
       - store_artifacts:
           path: playwright-report
-      - store_artifacts:
-          path: e2e-results
   deploy:
     machine:
       image: ubuntu-2004:202104-01


### PR DESCRIPTION
It doesn't seem to serve a purpose and just burns time.