### PR TITLE
Get rid of npm serve script

### DIFF
--- a/dev-scripts/serve-frontend
+++ b/dev-scripts/serve-frontend
@@ -15,4 +15,5 @@ cd "${SCRIPT_DIR}/.."
 
 . dev.env
 cd frontend
-npm run serve
+
+./node_modules/.bin/vue-cli-service serve --port 8085

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve --port 8085",
     "build": "vue-cli-service build",
     "check-format": "prettier --check ../**/*.js  ../**/*.json",
     "format": "prettier --write  ../**/*.js  ../**/*.json",


### PR DESCRIPTION
It's just more complicated to go through npm when we can avoid it.