### PR TITLE
Get rid of frontend/.env.dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ LITESTREAM_SECRET_ACCESS_KEY=''
 LITESTREAM_BUCKET='my-bucket-name'                           # Replace
 
 VUE_APP_USERKIT_APP_ID='dummy'                               # Replace
+VUE_APP_BACKEND_URL='http://localhost:3001'                  # Replace
 USERKIT_SECRET="dummy.dummy"                                 # Replace
 CSRF_SECRET_SEED="dummy-dev-secret-seed"                     # Replace
 

--- a/dev-scripts/serve-frontend
+++ b/dev-scripts/serve-frontend
@@ -16,6 +16,9 @@ cd "${SCRIPT_DIR}/.."
 
 # shellcheck disable=SC1091
 . .env.dev
+export VUE_APP_USERKIT_APP_ID
+export VUE_APP_BACKEND_URL
+
 cd frontend
 
 ./node_modules/.bin/vue-cli-service serve --port 8085

--- a/frontend/.env.dev
+++ b/frontend/.env.dev
@@ -1,2 +1,0 @@
-VUE_APP_BACKEND_URL='http://localhost:3001'
-VUE_APP_USERKIT_APP_ID='dummy'


### PR DESCRIPTION
It now is just the root .env.dev file which isn't in source control